### PR TITLE
added support for various model apis. Changed to require schema from user. adjusted some testing paths to be correct.

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ A comprehensive toolkit for extracting structured data from unstructured text an
 - **Unified Schema System**: Progressive complexity from simple to nested to multiple schemas
 - **Structured Extraction**: Instructor + Pydantic schemas with fallback mechanisms
 - **Batch Processing**: Parallel execution for efficient large-scale processing
+- **Multi-Provider Support**: OpenAI, Anthropic, Google, Groq, Together AI, Fireworks AI
 
 ### Advanced Extraction
 - **Progressive Complexity**: Start simple, scale to complex nested structures
@@ -125,16 +126,47 @@ prompt_template: |
 Model and processing parameters are passed to the constructor:
 
 ```python
-delm = DELM(
-    schema_spec_path="example.schema_spec.yaml",
-    model_name="gpt-4o-mini",
-    temperature=0.0,
-    max_retries=3,
-    batch_size=10,
-    max_workers=4,
-    regex_fallback_pattern=r'\d+'  # Optional: custom regex for fallback extraction
-)
+# Using YAML configuration (recommended)
+delm = DELM.from_yaml("config.yaml")
+
+# Or using dictionary configuration
+config = {
+    "model": {
+        "provider": "openai",  # Default: "openai"
+        "name": "gpt-4o-mini",  # Default: "gpt-4o-mini"
+        "temperature": 0.0,
+        "max_retries": 3,
+        "batch_size": 10,
+        "max_workers": 4
+    },
+    "data": {"target_column": "text"},
+    "schema": {"spec_path": "schema.yaml"},
+    "experiment": {"name": "test"}
+}
+delm = DELM.from_dict(config)
 ```
+
+#### Provider and Model Configuration
+
+DELM separates provider and model name for better user experience:
+
+```yaml
+# Easy to switch models with the same provider
+model:
+  provider: "openai"
+  name: "gpt-4o-mini"      # Easy to change to "gpt-4" or "gpt-3.5-turbo"
+
+# Easy to switch providers
+model:
+  provider: "anthropic"    # Easy to change to "google" or "groq"
+  name: "claude-3-sonnet"
+```
+
+This approach makes it intuitive to:
+- **Switch models**: Just change the `name` field
+- **Switch providers**: Just change the `provider` field  
+- **Compare models**: Easy to test different models with the same provider
+- **Understand configuration**: Clear separation of provider vs model concepts
 
 #### Regex Fallback Configuration
 

--- a/SCHEMA_REFERENCE.md
+++ b/SCHEMA_REFERENCE.md
@@ -238,38 +238,6 @@ Each variable in your schema can be configured with these options:
   required: false
 ```
 
-## Prompt Customization
-
-### Custom Prompt Templates
-
-You can customize the extraction prompt for better results:
-
-```yaml
-prompt_template: |
-  You are assisting a finance professor who expects meticulous and reliable results.
-
-  Extract commodity price information from the following text:
-
-  {variables}
-
-  Text to analyze:
-  {text}
-
-  CRITICAL INSTRUCTIONS:
-  - ONLY extract commodities that are EXPLICITLY mentioned in the text
-  - If NO commodities are mentioned, return an empty list []
-  - Do NOT infer or guess commodity types based on company names or context
-  - Do NOT extract commodities just because a company might be in the energy sector
-  - Focus on EXPLICIT mentions of: oil, gas, copper, gold, silver, steel, aluminum
-  - For each commodity mentioned, create a separate entry with all relevant details
-  - If a field is not mentioned in the text, leave it as null/None rather than guessing
-
-  Examples of what NOT to extract:
-  - "1-800 CONTACTS" → NOT oil (even though contacts might use oil-based solutions)
-  - "Apple Inc." → NOT aluminum (even though phones contain aluminum)
-  - "Bank of America" → NOT gold (even though banks might trade gold)
-```
-
 ### Validation Features
 
 #### Text Validation
@@ -373,15 +341,6 @@ suggestions:
       allowed_values: ["feature", "bug", "ui", "performance"]
       required: false
 ```
-
-## Troubleshooting
-
-### Common Issues
-
-1. **Empty Results**: Check field descriptions and ensure they're clear and specific
-2. **Inconsistent Extraction**: Use `allowed_values` to constrain outputs
-3. **Missing Fields**: Set `required: true` for critical fields
-4. **False Positives**: Enable `validate_in_text: true` for fields that should only be extracted when explicitly mentioned
 
 ---
 

--- a/example.config.yaml
+++ b/example.config.yaml
@@ -3,14 +3,15 @@
 
 # Model configuration
 model:
-  name: "gpt-4o-mini"           # LLM model to use
-  temperature: 0.0              # Temperature for generation (0.0-2.0)
-  max_retries: 3                # Maximum API retries
-  batch_size: 10                # Batch size for processing
-  max_workers: 1                # Number of concurrent workers
-  base_delay: 1.0               # Base delay for retry handler (seconds)
-  dotenv_path: ".env"           # Path to .env file (optional, can be null)
-  regex_fallback_pattern: null  # Regex pattern for fallback (optional, can be null)
+  provider: "openai"                  # LLM provider (openai, anthropic, google, groq, together, fireworks)
+  name: "gpt-4o-mini"                 # LLM model name
+  temperature: 0.0                    # Temperature for generation (0.0-2.0)
+  max_retries: 3                      # Maximum API retries
+  batch_size: 10                      # Batch size for processing
+  max_workers: 1                      # Number of concurrent workers
+  base_delay: 1.0                     # Base delay for retry handler (seconds)
+  dotenv_path: ".env"                 # Path to .env file (optional, can be null)
+  regex_fallback_pattern: null        # Regex pattern for fallback (optional, can be null)
 
 # Data configuration
 data:
@@ -40,10 +41,32 @@ data:
 
 # Schema configuration
 schema:
-  spec_path: "tests/experiments/calls_test/schema_spec.yaml" # Path to schema specification file
+  spec_path: "tests/calls_test/schema_spec.yaml" # Path to schema specification file
   container_name: "data"        # Container name for nested schemas
-  prompt_template: null         # Custom prompt template (optional, null = use default)
-  # Example custom prompt:
+  prompt_template: |
+    You are assisting a finance professor who expects meticulous and reliable results.
+
+    Extract the following information from the text:
+
+    {variables}
+
+    Text to analyze:
+    {text}
+
+    CRITICAL INSTRUCTIONS:
+    - ONLY extract information that is EXPLICITLY mentioned in the text
+    - If NO relevant information is mentioned, return empty lists or null values
+    - Do NOT infer or guess based on context or company names
+    - Do NOT extract information just because it might be related
+    - For each item mentioned, create a separate entry with all relevant details
+    - If a field is not mentioned in the text, leave it as null/None rather than guessing
+    - Focus on extracting accurate, factual data as stated in the text
+
+    Examples of what NOT to extract:
+    - "1-800 CONTACTS" → NOT oil (even though contacts might use oil-based solutions)
+    - "Apple Inc." → NOT aluminum (even though phones contain aluminum)
+    - "Bank of America" → NOT gold (even though banks might trade gold)
+  # Example of a simpler prompt template:
   # prompt_template: |
   #   You are a financial data extraction expert. Extract the following information:
   #   

--- a/example.env
+++ b/example.env
@@ -1,1 +1,6 @@
-OPENAI_API_KEY=""
+OPENAI_API_KEY="your-openai-key"
+ANTHROPIC_API_KEY="your-anthropic-key"
+GOOGLE_API_KEY="your-google-key"
+GROQ_API_KEY="your-groq-key"
+TOGETHER_API_KEY="your-together-key"
+FIREWORKS_API_KEY="your-fireworks-key"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,6 +49,26 @@ dev = [
     "mypy>=1.0.0",
 ]
 
+# Optional LLM providers
+anthropic = [
+    "anthropic>=0.7.0",
+]
+
+google = [
+    "google-generativeai>=0.3.0",
+]
+
+groq = [
+    "groq>=0.4.0",
+]
+
+# All providers
+all-providers = [
+    "anthropic>=0.7.0",
+    "google-generativeai>=0.3.0",
+    "groq>=0.4.0",
+]
+
 [project.urls]
 Homepage = "https://github.com/your-org/delm"
 Repository = "https://github.com/your-org/delm"

--- a/src/delm/DELM.py
+++ b/src/delm/DELM.py
@@ -47,15 +47,11 @@ class DELM:
         self,
         config: DELMConfig,
     ) -> None:
-        # Validate and store config
-        config.validate()
+        # Config
         self.config = config
         
         # Initialize components using composition
         self._initialize_components()
-        
-        # Runtime artefacts
-        self.raw_df: pd.DataFrame | None = None
 
     @classmethod
     def from_yaml(cls, config_path: Union[str, Path]) -> "DELM":
@@ -105,13 +101,9 @@ class DELM:
     def _initialize_components(self) -> None:
         """Initialize all components using composition."""
         # Environment & secrets -------------------------------------------- #
-        # TODO: likely abstract to a api_key_manager class once we add more models
         if self.config.model.dotenv_path:
             dotenv.load_dotenv(self.config.model.dotenv_path)
-        self.api_key: str | None = os.getenv("OPENAI_API_KEY")
-        if self.api_key and openai is not None:
-            openai.api_key = self.api_key
-
+        
         # Initialize components
         self.data_processor = DataProcessor(self.config.data)
         self.schema_manager = SchemaManager(self.config.schema)
@@ -119,7 +111,6 @@ class DELM:
         self.extraction_manager = ExtractionManager(
             self.config.model,
             schema_manager=self.schema_manager,  # Pass the instance
-            api_key=self.api_key
         )
 
 

--- a/src/delm/constants.py
+++ b/src/delm/constants.py
@@ -6,8 +6,9 @@ Default values for configuration, grouped by category.
 from pathlib import Path
 
 # API/Model Defaults
-DEFAULT_MODEL_NAME = "gpt-4o-mini"  # Default LLM model name
-DEFAULT_TEMPERATURE = 0.0            # Default temperature for LLM
+DEFAULT_PROVIDER = "openai"           # Default LLM provider (openai, anthropic, google, etc.)
+DEFAULT_MODEL_NAME = "gpt-4o-mini"    # Default LLM model name
+DEFAULT_TEMPERATURE = 0.0             # Default temperature for LLM
 DEFAULT_MAX_RETRIES = 3              # Default max retries for API calls
 DEFAULT_BATCH_SIZE = 10              # Default batch size for processing
 DEFAULT_MAX_WORKERS = 1              # Default number of concurrent workers

--- a/src/delm/core/__init__.py
+++ b/src/delm/core/__init__.py
@@ -5,11 +5,11 @@ Main processing components that orchestrate the extraction pipeline.
 """
 
 from .data_processor import DataProcessor
-from .extraction_manager import ExtractionManager
 from .experiment_manager import ExperimentManager
+from .extraction_manager import ExtractionManager
 
 __all__ = [
     "DataProcessor",
-    "ExtractionManager", 
-    "ExperimentManager",
+    "ExperimentManager", 
+    "ExtractionManager",
 ] 

--- a/tests/calls_test/config.yaml
+++ b/tests/calls_test/config.yaml
@@ -3,6 +3,7 @@
 
 # Model configuration
 model:
+  provider: "openai"
   name: "gpt-4o-mini"
   temperature: 0.0
   max_retries: 3
@@ -32,7 +33,7 @@ data:
 
 # Schema configuration
 schema:
-  spec_path: "tests/experiments/calls_test/schema_spec.yaml"
+  spec_path: "tests/calls_test/schema_spec.yaml"
   container_name: "commodities"
   prompt_template: null  # Use default prompt template
 

--- a/tests/calls_test/earning_report_delm_testing.py
+++ b/tests/calls_test/earning_report_delm_testing.py
@@ -25,8 +25,8 @@ TEST_KEYWORDS = (
     "using"
 )
 
-TEST_FILE_PATH = Path("tests/experiments/calls_test/data/input/input2_sample_1000.parquet")
-CONFIG_PATH = Path("tests/experiments/calls_test/config.yaml")
+TEST_FILE_PATH = Path("tests/calls_test/data/input/input2_sample_1000.parquet")
+CONFIG_PATH = Path("tests/calls_test/config.yaml")
 
 def load_test_data(file_path: Path, num_rows: int = 2) -> pd.DataFrame:
     """

--- a/tests/mock_test/config.yaml
+++ b/tests/mock_test/config.yaml
@@ -3,6 +3,7 @@
 
 # Model configuration
 model:
+  provider: "openai"
   name: "gpt-4o-mini"
   temperature: 0.0
   max_retries: 3


### PR DESCRIPTION
Multi-provider support
-     Added support for OpenAI, Anthropic, Google, Groq, Together, and Fireworks
-     Configuration now separates provider and name fields for clarity
-     Uses Instructor.from_provider() for unified client setup

Config and environment handling
-     .env now supports multiple providers (e.g., ANTHROPIC_API_KEY, GOOGLE_API_KEY)
-     Deprecated from_env() method — YAML and dict configs are now preferred

Schema enforcement
-     Extraction now requires a defined schema
-     Reduces reliance on regex fallback and improves consistency
-     Supports custom prompt templates directly via YAML

Cleanup and refactoring
-     Updated example configs and test paths for clarity
-     Removed outdated sections from SCHEMA_REFERENCE.md
-     Improved README.md with better usage examples and config explanation