### PR TITLE
Few-shot prompts, cost upper bound, strict budgets, and v1.2.0

### DIFF
--- a/docs/reference/config.md
+++ b/docs/reference/config.md
@@ -74,6 +74,7 @@ LLM and extraction settings.
 - `model_input_cost_per_1M_tokens`, `model_output_cost_per_1M_tokens`
 - `prompt_template`, `system_prompt`
 - `api_kwargs`
+- `few_shot_examples`, `few_shot_num_examples`, `few_shot_truncate_length`, `few_shot_random_sample`
 
 ---
 

--- a/docs/reference/cost-estimation.md
+++ b/docs/reference/cost-estimation.md
@@ -35,6 +35,38 @@ cost_report = estimate_input_token_cost(
 
 **Note:** Counts cached requests toward token cost (they would be cached on first run).
 
+## estimate_max_total_cost()
+
+Estimate an upper bound on total cost (free, no API calls). For each chunk the
+output tokens are bounded by
+`min(max_completion_tokens, context_window - input_tokens)`, so the bound is
+
+```
+input_price * input_tokens
++ output_price * min(max_completion_tokens, context_window - input_tokens)
+```
+
+summed over all chunks. Context window and max output tokens are looked up
+from the tokencost database; when unavailable (custom models with manual price
+overrides), only `max_completion_tokens` bounds the output.
+
+```python
+from delm.utils.cost_estimation import estimate_max_total_cost
+
+max_cost = estimate_max_total_cost(
+    config: DELM | DELMConfig | str | Path,
+    data_source: str | Path | pd.DataFrame,
+    save_file_log: bool = False,
+    log_dir: str | Path | None = ".delm/logs/cost_estimation",
+    console_log_level: str = "INFO",
+    file_log_level: str = "DEBUG"
+) -> float
+```
+
+**Parameters:** Same as `estimate_input_token_cost()`.
+
+**Returns:** Upper-bound dollar cost (float) for processing all chunks.
+
 ## estimate_total_cost()
 
 Estimate total cost (input + output tokens) using sample API calls.

--- a/docs/reference/cost-estimation.md
+++ b/docs/reference/cost-estimation.md
@@ -9,14 +9,14 @@ Estimate cost based on input tokens only (free, no API calls).
 ```python
 from delm.utils.cost_estimation import estimate_input_token_cost
 
-cost_report = estimate_input_token_cost(
+input_cost = estimate_input_token_cost(
     config: DELM | DELMConfig | str | Path,
     data_source: str | Path | pd.DataFrame,
     save_file_log: bool = False,
     log_dir: str | Path | None = ".delm/logs/cost_estimation",
     console_log_level: str = "INFO",
     file_log_level: str = "DEBUG"
-) -> dict
+) -> float
 ```
 
 **Parameters:**
@@ -27,11 +27,7 @@ cost_report = estimate_input_token_cost(
 - `console_log_level`: Console verbosity
 - `file_log_level`: File verbosity
 
-**Returns:** Dictionary with:
-- `estimated_input_tokens` (int)
-- `estimated_input_cost` (float)
-- `num_records` (int)
-- `num_chunks` (int)
+**Returns:** Estimated dollar cost (float) of input tokens for all chunks.
 
 **Note:** Counts cached requests toward token cost (they would be cached on first run).
 
@@ -74,7 +70,7 @@ Estimate total cost (input + output tokens) using sample API calls.
 ```python
 from delm.utils.cost_estimation import estimate_total_cost
 
-cost_report = estimate_total_cost(
+total_cost = estimate_total_cost(
     config: DELM | DELMConfig | str | Path,
     data_source: str | Path | pd.DataFrame,
     sample_size: int = 10,
@@ -82,23 +78,17 @@ cost_report = estimate_total_cost(
     log_dir: str | Path | None = ".delm/logs/cost_estimation",
     console_log_level: str = "INFO",
     file_log_level: str = "DEBUG"
-) -> dict
+) -> float
 ```
 
 **Parameters:**
 - `config`: DELM instance, DELMConfig, or path to config YAML
 - `data_source`: Input data
-- `sample_size`: Number of chunks to sample for estimation
+- `sample_size`: Number of records to sample for estimation
 - `save_file_log`, `log_dir`, `console_log_level`, `file_log_level`: Logging settings
 
-**Returns:** Dictionary with:
-- `estimated_total_cost` (float)
-- `estimated_input_tokens` (int)
-- `estimated_output_tokens` (int)
-- `estimated_input_cost` (float)
-- `estimated_output_cost` (float)
-- `sample_size` (int)
-- `total_chunks` (int)
+**Returns:** Estimated dollar cost (float) for processing the entire dataset,
+extrapolated from the sample by input-token share.
 
 **Warning:** Makes real API calls (costs apply).
 
@@ -122,10 +112,10 @@ delm = DELM(
 
 # Free estimate (input tokens only)
 input_cost = estimate_input_token_cost(delm, "data.csv")
-print(f"Input cost: ${input_cost['estimated_input_cost']:.4f}")
+print(f"Input cost: ${input_cost:.4f}")
 
 # Sample-based estimate (costs ~$0.01)
 total_cost = estimate_total_cost(delm, "data.csv", sample_size=10)
-print(f"Total estimated cost: ${total_cost['estimated_total_cost']:.2f}")
+print(f"Total estimated cost: ${total_cost:.2f}")
 ```
 

--- a/docs/reference/delm.md
+++ b/docs/reference/delm.md
@@ -66,6 +66,10 @@ delm = DELM(
 |-----------|------|---------|-------------|
 | `prompt_template` | `str \| None` | `"Extract the following..."` | User prompt template |
 | `system_prompt` | `str \| None` | `"You are a precise..."` | System prompt |
+| `few_shot_examples` | `list[dict] \| None` | `None` | Pool of hand-labeled examples, each with `"text"` and `"output"` keys |
+| `few_shot_num_examples` | `int` | `3` | Number of few-shot examples included per prompt |
+| `few_shot_truncate_length` | `int \| None` | `None` | Max token length per example text (`None` = no truncation) |
+| `few_shot_random_sample` | `bool` | `False` | Randomly sample examples from the pool per request (seeded) |
 
 ### Caching
 

--- a/docs/user-guide/cost-management.md
+++ b/docs/user-guide/cost-management.md
@@ -89,6 +89,8 @@ print(f"Estimated total cost: ${total_cost:.2f}")
 
 You can set a hard budget limit to ensure you never accidentally overspend. If the limit is reached, DELM stops processing immediately but preserves all results extracted up to that point.
 
+Before dispatching each request, DELM reserves its worst-case cost (input tokens plus `max_completion_tokens`) against the budget, so even with many concurrent workers the in-flight requests cannot overshoot `max_budget`.
+
 ```python
 from delm import DELM
 

--- a/docs/user-guide/cost-management.md
+++ b/docs/user-guide/cost-management.md
@@ -6,7 +6,7 @@ DELM provides tools to estimate costs before running a job, track costs during e
 
 Before running a large extraction job, you should estimate the potential cost. DELM offers two methods for this: a free input-only estimate and a more accurate sample-based estimate.
 
-**Note on Pricing**: DELM uses the [tokencost](https://github.com/AgentOps-AI/tokencost) package to look up model prices automatically (400+ models supported). If your model isn't in the database or prices have changed, override with `model_input_cost_per_1M_tokens` and `model_output_cost_per_1M_tokens`.
+**Note on Pricing**: DELM uses the [tokencost](https://github.com/AgentOps-AI/tokencost) package to look up model prices automatically. If a model is missing from the bundled database (e.g. a model released after your tokencost version), DELM fetches tokencost's live price feed once per process, so newly released models (such as `claude-fable-5` or `gpt-5.6-sol`) resolve without an upgrade. If the model still isn't found or prices have changed, override with `model_input_cost_per_1M_tokens` and `model_output_cost_per_1M_tokens`.
 
 ### 1. Input Token Estimation (Free)
 
@@ -34,7 +34,27 @@ input_cost = estimate_input_token_cost(
 print(f"Estimated minimum cost (input only): ${input_cost:.2f}")
 ```
 
-### 2. Total Cost Estimation (Sampled)
+### 2. Upper-Bound Estimation (Free)
+
+This method computes a **worst-case total cost** without API calls. Output
+tokens per chunk are bounded by
+`min(max_completion_tokens, context_window - input_tokens)`, using the model's
+limits from the tokencost database.
+
+**Best for**: Knowing the maximum you could possibly spend before launching a job.
+
+```python
+from delm.utils.cost_estimation import estimate_max_total_cost
+
+max_cost = estimate_max_total_cost(
+    config=delm,
+    data_source="data/financial_reports.csv"
+)
+
+print(f"Worst-case total cost: ${max_cost:.2f}")
+```
+
+### 3. Total Cost Estimation (Sampled)
 
 This method runs the full extraction pipeline on a small sample of your data to measure both **input and output** tokens. It then extrapolates the total cost.
 

--- a/docs/user-guide/prompt-customization.md
+++ b/docs/user-guide/prompt-customization.md
@@ -141,6 +141,42 @@ Note: Normalize all extracted values to English."""
 
 - **`{text}`** - The text chunk to extract from (required)
 - **`{variables}`** - Auto-generated list of variables from your schema (required)
+- **`{examples}`** - Rendered few-shot examples block (optional, see below)
+
+## Few-Shot Examples
+
+Include hand-labeled examples in the prompt to improve extraction quality.
+Each example is a dict with a `"text"` key (source text) and an `"output"`
+key (expected extraction result as a dict or JSON string).
+
+```python
+delm = DELM(
+    schema=schema,
+    few_shot_examples=[
+        {
+            "text": "Brent crude is forecast to hit $85 per barrel in Q4.",
+            "output": {"commodity": "Brent crude", "price_value": 85},
+        },
+        {
+            "text": "Gold remained flat this week.",
+            "output": {"commodity": "gold", "price_value": None},
+        },
+    ],
+    few_shot_num_examples=2,        # examples per prompt
+    few_shot_truncate_length=200,   # max tokens per example text (None = no truncation)
+    few_shot_random_sample=True,    # sample randomly from the pool per request
+)
+```
+
+Notes:
+
+- The rendered examples block replaces the `{examples}` placeholder in your
+  `prompt_template` if present; otherwise it is prepended to the template.
+- Random sampling is seeded (`SYSTEM_RANDOM_SEED = 42`), so runs are reproducible.
+- If fewer examples are available than requested, all available examples are
+  used and a warning is logged.
+- Few-shot examples count toward input tokens; cost estimation utilities
+  include them automatically.
 
 ## 3. System Prompt
 

--- a/docs/user-guide/prompt-customization.md
+++ b/docs/user-guide/prompt-customization.md
@@ -141,7 +141,6 @@ Note: Normalize all extracted values to English."""
 
 - **`{text}`** - The text chunk to extract from (required)
 - **`{variables}`** - Auto-generated list of variables from your schema (required)
-- **`{examples}`** - Rendered few-shot examples block (optional, see below)
 
 ## Few-Shot Examples
 
@@ -170,8 +169,8 @@ delm = DELM(
 
 Notes:
 
-- The rendered examples block replaces the `{examples}` placeholder in your
-  `prompt_template` if present; otherwise it is prepended to the template.
+- The rendered examples block is prepended once to the final prompt (this also
+  holds for `Schema.multiple`, which repeats the template per sub-schema).
 - Random sampling is seeded (`SYSTEM_RANDOM_SEED = 42`), so runs are reproducible.
 - If fewer examples are available than requested, all available examples are
   used and a warning is logged.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -91,7 +91,7 @@ extend-exclude = '''
 '''
 
 [tool.mypy]
-python_version = "1.1.0"
+python_version = "3.10"
 warn_return_any = true
 warn_unused_configs = true
 disallow_untyped_defs = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "delm"
-version = "1.1.0"
+version = "1.2.0"
 description = "DELM:Data Extraction with Language Models"
 readme = "README.md"
 license = { text = "MIT" }

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -13,10 +13,17 @@ from pathlib import Path
 def update_version(version: str):
     """Update version in pyproject.toml and __init__.py"""
 
-    # Update pyproject.toml
+    # Update pyproject.toml. The pattern is anchored to the start of the line
+    # so it cannot match other keys such as mypy's python_version.
     pyproject_path = Path("pyproject.toml")
     content = pyproject_path.read_text()
-    content = re.sub(r'version = "[^"]*"', f'version = "{version}"', content)
+    content = re.sub(
+        r'^version = "[^"]*"',
+        f'version = "{version}"',
+        content,
+        count=1,
+        flags=re.MULTILINE,
+    )
     pyproject_path.write_text(content)
     print(f"✅ Updated pyproject.toml to version {version}")
 

--- a/src/delm/__init__.py
+++ b/src/delm/__init__.py
@@ -45,7 +45,7 @@ from .constants import (
 from delm.schemas import Schema
 from delm.models import ExtractionVariable
 
-__version__ = "1.1.0"
+__version__ = "1.2.0"
 __author__ = "Eric Fithian - Chicago Booth CAAI Lab"
 
 __all__ = [

--- a/src/delm/config.py
+++ b/src/delm/config.py
@@ -18,6 +18,7 @@ T = TypeVar("T", bound="BaseConfig")
 from delm.strategies import RelevanceScorer
 from delm.strategies import SplitStrategy
 from delm.schemas import Schema
+from delm.utils.few_shot import validate_few_shot_params
 
 
 class BaseConfig:
@@ -68,6 +69,10 @@ class LLMExtractionConfig(BaseConfig):
     model_output_cost_per_1M_tokens: Optional[float]
     max_completion_tokens: int
     api_kwargs: dict
+    few_shot_examples: Optional[List[Dict[str, Any]]] = None
+    few_shot_num_examples: int = 3
+    few_shot_truncate_length: Optional[int] = None
+    few_shot_random_sample: bool = False
 
     def get_provider_string(self) -> str:
         """Return the combined provider string for Instructor.
@@ -156,6 +161,16 @@ class LLMExtractionConfig(BaseConfig):
             raise ValueError(
                 f"api_kwargs must be a dict. api_kwargs: {self.api_kwargs}"
             )
+        if not isinstance(self.few_shot_random_sample, bool):
+            raise ValueError(
+                f"few_shot_random_sample must be a boolean. few_shot_random_sample: {self.few_shot_random_sample}"
+            )
+        if self.few_shot_examples is not None:
+            validate_few_shot_params(
+                self.few_shot_examples,
+                self.few_shot_num_examples,
+                self.few_shot_truncate_length,
+            )
 
     def to_dict(self) -> dict:
         return {
@@ -179,6 +194,10 @@ class LLMExtractionConfig(BaseConfig):
             "model_output_cost_per_1M_tokens": self.model_output_cost_per_1M_tokens,
             "max_completion_tokens": self.max_completion_tokens,
             "api_kwargs": self.api_kwargs,
+            "few_shot_examples": self.few_shot_examples,
+            "few_shot_num_examples": self.few_shot_num_examples,
+            "few_shot_truncate_length": self.few_shot_truncate_length,
+            "few_shot_random_sample": self.few_shot_random_sample,
         }
 
 
@@ -470,6 +489,10 @@ class DELMConfig:
         model_output_cost_per_1M_tokens: Optional[float] = None,
         max_completion_tokens: int = 4096,
         api_kwargs: Optional[Dict[str, Any]] = None,
+        few_shot_examples: Optional[List[Dict[str, Any]]] = None,
+        few_shot_num_examples: int = 3,
+        few_shot_truncate_length: Optional[int] = None,
+        few_shot_random_sample: bool = False,
         # Data Preprocessing (flat)
         target_column: str = "text",
         drop_target_column: bool = False,
@@ -536,6 +559,10 @@ class DELMConfig:
             model_output_cost_per_1M_tokens=model_output_cost_per_1M_tokens,
             max_completion_tokens=max_completion_tokens,
             api_kwargs=api_kwargs if api_kwargs is not None else {},
+            few_shot_examples=few_shot_examples,
+            few_shot_num_examples=few_shot_num_examples,
+            few_shot_truncate_length=few_shot_truncate_length,
+            few_shot_random_sample=few_shot_random_sample,
         )
         self.data_preprocessing_cfg = DataPreprocessingConfig(
             target_column=target_column,
@@ -602,6 +629,10 @@ class DELMConfig:
             model_output_cost_per_1M_tokens=data["model_output_cost_per_1M_tokens"],
             max_completion_tokens=data.get("max_completion_tokens", 4096),
             api_kwargs=data.get("api_kwargs", {}),
+            few_shot_examples=data.get("few_shot_examples"),
+            few_shot_num_examples=data.get("few_shot_num_examples", 3),
+            few_shot_truncate_length=data.get("few_shot_truncate_length"),
+            few_shot_random_sample=data.get("few_shot_random_sample", False),
             target_column=data["target_column"],
             drop_target_column=data["drop_target_column"],
             splitting_strategy=data["splitting_strategy"],

--- a/src/delm/config.py
+++ b/src/delm/config.py
@@ -7,10 +7,13 @@ and the top‑level ``DELMConfig`` aggregator.
 Docstrings follow Google style.
 """
 
+import logging
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any, Dict, Optional, Union, TypeVar, List
 import yaml
+
+log = logging.getLogger(__name__)
 
 T = TypeVar("T", bound="BaseConfig")
 
@@ -594,54 +597,76 @@ class DELMConfig:
 
         return data
 
+    # Keys accepted by ``from_dict`` besides the required ``schema``.
+    _FROM_DICT_KEYS = (
+        "provider",
+        "model",
+        "base_url",
+        "mode",
+        "temperature",
+        "prompt_template",
+        "system_prompt",
+        "batch_size",
+        "max_workers",
+        "max_retries",
+        "base_delay",
+        "rate_limit_tokens",
+        "rate_limit_requests",
+        "rate_limit_period_seconds",
+        "track_cost",
+        "max_budget",
+        "model_input_cost_per_1M_tokens",
+        "model_output_cost_per_1M_tokens",
+        "max_completion_tokens",
+        "api_kwargs",
+        "few_shot_examples",
+        "few_shot_num_examples",
+        "few_shot_truncate_length",
+        "few_shot_random_sample",
+        "target_column",
+        "drop_target_column",
+        "splitting_strategy",
+        "relevance_scorer",
+        "score_filter",
+        "cache_backend",
+        "cache_path",
+        "cache_max_size_mb",
+        "cache_synchronous",
+    )
+
     @classmethod
     def from_dict(cls, data: Dict[str, Any]) -> "DELMConfig":
         """Create ``DELMConfig`` from a mapping.
 
-        Handles two formats:
-        1. Nested format (from to_dict()): Has 'llm_extraction', 'data_preprocessing', 'semantic_cache' keys
-        2. Flat format: All fields at top level
+        Only ``schema`` is required. Any other key that is absent falls back
+        to the ``DELMConfig`` constructor default, so configs saved by older
+        versions keep loading after new fields are added.
+
+        Args:
+            data: Mapping of configuration options.
+
+        Returns:
+            A configured ``DELMConfig`` instance.
+
+        Raises:
+            ValueError: If ``schema`` is missing.
         """
         if data is None:
             data = {}
+        if "schema" not in data:
+            raise ValueError(
+                "Config dict must contain a 'schema' key. "
+                f"Got keys: {sorted(data.keys())}"
+            )
 
-        # Check if this is nested format (from to_dict())
-        return cls(
-            schema=data["schema"],
-            provider=data["provider"],
-            model=data["model"],
-            base_url=data["base_url"],
-            mode=data["mode"],
-            temperature=data["temperature"],
-            prompt_template=data["prompt_template"],
-            system_prompt=data["system_prompt"],
-            batch_size=data["batch_size"],
-            max_workers=data["max_workers"],
-            max_retries=data["max_retries"],
-            base_delay=data["base_delay"],
-            rate_limit_tokens=data["rate_limit_tokens"],
-            rate_limit_requests=data["rate_limit_requests"],
-            rate_limit_period_seconds=data.get("rate_limit_period_seconds", 60.0),
-            track_cost=data["track_cost"],
-            max_budget=data["max_budget"],
-            model_input_cost_per_1M_tokens=data["model_input_cost_per_1M_tokens"],
-            model_output_cost_per_1M_tokens=data["model_output_cost_per_1M_tokens"],
-            max_completion_tokens=data.get("max_completion_tokens", 4096),
-            api_kwargs=data.get("api_kwargs", {}),
-            few_shot_examples=data.get("few_shot_examples"),
-            few_shot_num_examples=data.get("few_shot_num_examples", 3),
-            few_shot_truncate_length=data.get("few_shot_truncate_length"),
-            few_shot_random_sample=data.get("few_shot_random_sample", False),
-            target_column=data["target_column"],
-            drop_target_column=data["drop_target_column"],
-            splitting_strategy=data["splitting_strategy"],
-            relevance_scorer=data["relevance_scorer"],
-            score_filter=data["score_filter"],
-            cache_backend=data["cache_backend"],
-            cache_path=data["cache_path"],
-            cache_max_size_mb=data["cache_max_size_mb"],
-            cache_synchronous=data["cache_synchronous"],
-        )
+        unknown_keys = set(data) - set(cls._FROM_DICT_KEYS) - {"schema"}
+        if unknown_keys:
+            log.warning(
+                "Ignoring unknown config keys: %s", sorted(unknown_keys)
+            )
+
+        kwargs = {key: data[key] for key in cls._FROM_DICT_KEYS if key in data}
+        return cls(schema=data["schema"], **kwargs)
 
     @classmethod
     def from_yaml(cls, path: Union[str, Path]) -> "DELMConfig":

--- a/src/delm/config.py
+++ b/src/delm/config.py
@@ -13,7 +13,6 @@ from typing import Any, Dict, Optional, Union, TypeVar, List
 import yaml
 
 T = TypeVar("T", bound="BaseConfig")
-T = TypeVar("T", bound="BaseConfig")
 
 from delm.strategies import RelevanceScorer
 from delm.strategies import SplitStrategy
@@ -657,8 +656,6 @@ class DELMConfig:
         Raises:
             FileNotFoundError: If the file does not exist.
         """
-        if isinstance(path, str):
-            path = Path(path)
         if isinstance(path, str):
             path = Path(path)
         if not path.exists():

--- a/src/delm/core/extraction_manager.py
+++ b/src/delm/core/extraction_manager.py
@@ -30,6 +30,7 @@ from delm.constants import (
 from delm.exceptions import InstructorError
 from delm.utils.cost_tracker import CostTracker
 from delm.core.experiment_manager import BaseExperimentManager
+from delm.utils.few_shot import FewShotExampleSelector
 from delm.utils.type_checks import is_pydantic_model
 from delm.utils.semantic_cache import SemanticCache, make_cache_key
 
@@ -139,6 +140,20 @@ class ExtractionManager:
 
         self.prompt_template = model_config.prompt_template
         self.system_prompt = model_config.system_prompt
+
+        self.few_shot_selector = FewShotExampleSelector.from_optional(
+            examples=model_config.few_shot_examples,
+            num_examples=model_config.few_shot_num_examples,
+            truncate_length=model_config.few_shot_truncate_length,
+            random_sample=model_config.few_shot_random_sample,
+        )
+        if self.few_shot_selector is not None:
+            log.debug(
+                "Few-shot selector created with %d examples (num=%d, random=%s)",
+                len(model_config.few_shot_examples),
+                model_config.few_shot_num_examples,
+                model_config.few_shot_random_sample,
+            )
 
         self.cost_tracker = cost_tracker
         self.semantic_cache = semantic_cache
@@ -435,7 +450,12 @@ class ExtractionManager:
         """
         # Hot path - minimal logging. Schema is cached internally.
         schema = self.extraction_schema.create_pydantic_schema()
-        prompt = self.extraction_schema.create_prompt(text_chunk, self.prompt_template)
+        prompt_template = self.prompt_template
+        if self.few_shot_selector is not None:
+            prompt_template = self.few_shot_selector.inject_into_template(
+                prompt_template
+            )
+        prompt = self.extraction_schema.create_prompt(text_chunk, prompt_template)
         system_prompt = self.system_prompt
 
         estimated_total_tokens = self._estimate_total_tokens(

--- a/src/delm/core/extraction_manager.py
+++ b/src/delm/core/extraction_manager.py
@@ -458,9 +458,10 @@ class ExtractionManager:
         prompt = self.extraction_schema.create_prompt(text_chunk, prompt_template)
         system_prompt = self.system_prompt
 
-        estimated_total_tokens = self._estimate_total_tokens(
+        estimated_input_tokens = self._estimate_input_tokens(
             system_prompt, prompt, schema, tokenize=True
         )
+        estimated_total_tokens = estimated_input_tokens + self.max_output_tokens
 
         def _instructor_extract():
             self.rate_limiter.before_request(est_tokens=estimated_total_tokens)
@@ -549,7 +550,24 @@ class ExtractionManager:
         except Exception as e:
             log.error(f"Cache error {e}, performing new extraction")
 
-        response = self.retry_handler.execute_with_retry(_instructor_extract)
+        # Reserve the worst-case cost of this request against the budget so
+        # concurrent in-flight requests cannot overshoot max_budget.
+        reserved_cost = None
+        if self.cost_tracker is not None:
+            reserved_cost = self.cost_tracker.try_reserve_budget(
+                estimated_input_tokens, self.model_config.max_completion_tokens
+            )
+            if reserved_cost is None:
+                raise ValueError(
+                    "Over budget: request reservation would exceed max_budget"
+                )
+
+        try:
+            response = self.retry_handler.execute_with_retry(_instructor_extract)
+        finally:
+            if self.cost_tracker is not None and reserved_cost is not None:
+                self.cost_tracker.release_budget_reservation(reserved_cost)
+
         response_dict = response.model_dump(mode="json")
         # Convert to dict to save to semantic cache
         try:
@@ -558,14 +576,14 @@ class ExtractionManager:
             log.error(f"Cache error {e}, did not cache result")
         return response
 
-    def _estimate_total_tokens(
+    def _estimate_input_tokens(
         self,
         system_prompt: str,
         prompt: str,
         schema: BaseModel,
         tokenize: bool = True,
     ) -> int:
-        """Estimate the total tokens for a given system prompt, prompt, and schema."""
+        """Estimate the input tokens for a given system prompt, prompt, and schema."""
         # Include schema JSON for estimation alongside system + user prompt
         complete_prompt = (
             f"{system_prompt}\n{prompt}\n{json.dumps(schema.model_json_schema())}"
@@ -575,9 +593,7 @@ class ExtractionManager:
         else:
             input_tokens = len(complete_prompt) // 4
 
-        total_tokens = input_tokens + self.max_output_tokens
-
-        return total_tokens
+        return input_tokens
 
     def parse_results_dataframe(
         self,

--- a/src/delm/core/extraction_manager.py
+++ b/src/delm/core/extraction_manager.py
@@ -450,12 +450,9 @@ class ExtractionManager:
         """
         # Hot path - minimal logging. Schema is cached internally.
         schema = self.extraction_schema.create_pydantic_schema()
-        prompt_template = self.prompt_template
+        prompt = self.extraction_schema.create_prompt(text_chunk, self.prompt_template)
         if self.few_shot_selector is not None:
-            prompt_template = self.few_shot_selector.inject_into_template(
-                prompt_template
-            )
-        prompt = self.extraction_schema.create_prompt(text_chunk, prompt_template)
+            prompt = self.few_shot_selector.prepend_to_prompt(prompt)
         system_prompt = self.system_prompt
 
         estimated_input_tokens = self._estimate_input_tokens(

--- a/src/delm/core/extraction_manager.py
+++ b/src/delm/core/extraction_manager.py
@@ -10,7 +10,6 @@ from typing import Any, Optional, Dict, List
 import pandas as pd
 import instructor
 from pydantic import BaseModel
-import tiktoken
 
 from delm.utils.rate_limiter import RateLimiter
 
@@ -28,7 +27,7 @@ from delm.constants import (
     SYSTEM_EXTRACTED_DATA_JSON_COLUMN,
 )
 from delm.exceptions import InstructorError
-from delm.utils.cost_tracker import CostTracker
+from delm.utils.cost_tracker import CostTracker, get_tokenizer_for_model
 from delm.core.experiment_manager import BaseExperimentManager
 from delm.utils.few_shot import FewShotExampleSelector
 from delm.utils.type_checks import is_pydantic_model
@@ -158,6 +157,7 @@ class ExtractionManager:
         self.cost_tracker = cost_tracker
         self.semantic_cache = semantic_cache
         self.rate_limiter = rate_limiter
+        self.tokenizer = get_tokenizer_for_model(model_config.model)
 
         self.max_output_tokens = 0
 
@@ -571,8 +571,7 @@ class ExtractionManager:
             f"{system_prompt}\n{prompt}\n{json.dumps(schema.model_json_schema())}"
         )
         if tokenize:
-            tokenizer = tiktoken.get_encoding("cl100k_base")
-            input_tokens = len(tokenizer.encode(complete_prompt))
+            input_tokens = len(self.tokenizer.encode(complete_prompt))
         else:
             input_tokens = len(complete_prompt) // 4
 

--- a/src/delm/delm.py
+++ b/src/delm/delm.py
@@ -31,8 +31,9 @@ from delm.constants import (
 )
 from delm.strategies import SplitStrategy, RelevanceScorer
 from delm.utils.cost_tracker import CostTracker
+from delm.utils.few_shot import FewShotExampleSelector
 from delm.utils.semantic_cache import SemanticCacheFactory
-from typing import Any, Union, Optional
+from typing import Any, Dict, List, Union, Optional
 
 # --------------------------------------------------------------------------- #
 # Main class                                                                  #
@@ -67,6 +68,10 @@ class DELM:
         model_output_cost_per_1M_tokens: Optional[float] = None,
         max_completion_tokens: int = 4096,
         api_kwargs: Optional[Dict[str, Any]] = None,
+        few_shot_examples: Optional[List[Dict[str, Any]]] = None,
+        few_shot_num_examples: int = 3,
+        few_shot_truncate_length: Optional[int] = None,
+        few_shot_random_sample: bool = False,
         # Data Preprocessing (flat)
         target_column: str = "text",
         drop_target_column: bool = False,
@@ -129,6 +134,14 @@ class DELM:
                 Uses tokencost pricing if not specified.
             api_kwargs: Extra keyword arguments passed through to the underlying LLM API
                 call (e.g. ``{"store": False}`` for Fireworks AI).
+            few_shot_examples: Pool of hand-labeled examples to include in the
+                extraction prompt. Each example is a dict with ``"text"`` (source
+                text) and ``"output"`` (expected extraction as dict or JSON string).
+            few_shot_num_examples: Number of few-shot examples to include per prompt.
+            few_shot_truncate_length: Maximum token length for each example's text.
+                ``None`` disables truncation.
+            few_shot_random_sample: Whether to randomly sample examples from the
+                pool for each request (seeded with ``SYSTEM_RANDOM_SEED``).
 
             target_column: Name of the column containing text to extract from.
             drop_target_column: Whether to drop the original target column after
@@ -185,6 +198,10 @@ class DELM:
             model_output_cost_per_1M_tokens=model_output_cost_per_1M_tokens,
             max_completion_tokens=max_completion_tokens,
             api_kwargs=api_kwargs,
+            few_shot_examples=few_shot_examples,
+            few_shot_num_examples=few_shot_num_examples,
+            few_shot_truncate_length=few_shot_truncate_length,
+            few_shot_random_sample=few_shot_random_sample,
             target_column=target_column,
             drop_target_column=drop_target_column,
             splitting_strategy=splitting_strategy,
@@ -281,6 +298,10 @@ class DELM:
             model_output_cost_per_1M_tokens=config.llm_extraction_cfg.model_output_cost_per_1M_tokens,
             max_completion_tokens=config.llm_extraction_cfg.max_completion_tokens,
             api_kwargs=config.llm_extraction_cfg.api_kwargs,
+            few_shot_examples=config.llm_extraction_cfg.few_shot_examples,
+            few_shot_num_examples=config.llm_extraction_cfg.few_shot_num_examples,
+            few_shot_truncate_length=config.llm_extraction_cfg.few_shot_truncate_length,
+            few_shot_random_sample=config.llm_extraction_cfg.few_shot_random_sample,
             target_column=config.data_preprocessing_cfg.target_column,
             drop_target_column=config.data_preprocessing_cfg.drop_target_column,
             splitting_strategy=config.data_preprocessing_cfg.splitting_strategy,
@@ -462,9 +483,19 @@ class DELM:
         target_column_name = self.config.data_preprocessing_cfg.target_column
         if text is None:
             text = f"<{target_column_name}>"
+        llm_cfg = self.config.llm_extraction_cfg
+        prompt_template = llm_cfg.prompt_template
+        few_shot_selector = FewShotExampleSelector.from_optional(
+            examples=llm_cfg.few_shot_examples,
+            num_examples=llm_cfg.few_shot_num_examples,
+            truncate_length=llm_cfg.few_shot_truncate_length,
+            random_sample=llm_cfg.few_shot_random_sample,
+        )
+        if few_shot_selector is not None:
+            prompt_template = few_shot_selector.inject_into_template(prompt_template)
         prompt = self.config.schema.schema.create_prompt(
             text=text,
-            prompt_template=self.config.llm_extraction_cfg.prompt_template,
+            prompt_template=prompt_template,
         )
         return prompt
 

--- a/src/delm/delm.py
+++ b/src/delm/delm.py
@@ -481,7 +481,10 @@ class DELM:
         if text is None:
             text = f"<{target_column_name}>"
         llm_cfg = self.config.llm_extraction_cfg
-        prompt_template = llm_cfg.prompt_template
+        prompt = self.config.schema.schema.create_prompt(
+            text=text,
+            prompt_template=llm_cfg.prompt_template,
+        )
         few_shot_selector = FewShotExampleSelector.from_optional(
             examples=llm_cfg.few_shot_examples,
             num_examples=llm_cfg.few_shot_num_examples,
@@ -489,11 +492,7 @@ class DELM:
             random_sample=llm_cfg.few_shot_random_sample,
         )
         if few_shot_selector is not None:
-            prompt_template = few_shot_selector.inject_into_template(prompt_template)
-        prompt = self.config.schema.schema.create_prompt(
-            text=text,
-            prompt_template=prompt_template,
-        )
+            prompt = few_shot_selector.prepend_to_prompt(prompt)
         return prompt
 
     ## ------------------------------ Private API ------------------------------- ##

--- a/src/delm/delm.py
+++ b/src/delm/delm.py
@@ -217,8 +217,6 @@ class DELM:
 
         # Configure logging
         if save_log_file:
-            if log_dir is None:
-                log_dir = log_dir
             current_time = datetime.now().strftime("%Y-%m-%d_%H-%M-%S")
             log_file_name = f"{log_file_prefix}{current_time}{SYSTEM_LOG_FILE_SUFFIX}"
         else:
@@ -232,7 +230,6 @@ class DELM:
             force=override_logging,
         )
 
-        log = logging.getLogger(__name__)
         log.debug("Initialising DELM…")
 
         # Validate configuration before proceeding

--- a/src/delm/utils/cost_estimation.py
+++ b/src/delm/utils/cost_estimation.py
@@ -1,18 +1,19 @@
 """Cost estimation helpers for DELM.
 
-Provides utilities to estimate approximate input token costs without API calls
-and total extraction costs using a sampled run.
+Provides utilities to estimate approximate input token costs without API calls,
+an upper bound on total cost without API calls, and total extraction costs
+using a sampled run.
 """
 
 from __future__ import annotations
 
-import logging
-from pathlib import Path
-from typing import Any, Dict, Union
-import pandas as pd
-from copy import deepcopy
-from typing import Optional
 import json
+import logging
+from datetime import datetime
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Union
+
+import pandas as pd
 
 from delm.delm import DELM
 from delm.constants import (
@@ -22,9 +23,117 @@ from delm.constants import (
     SYSTEM_LOG_FILE_SUFFIX,
 )
 from delm.config import DELMConfig
+from delm.logging import configure as configure_logging
+from delm.utils.few_shot import FewShotExampleSelector
+from delm.utils.model_price_database import get_model_token_limits
 
 # Module-level logger
 log = logging.getLogger(__name__)
+
+# --------------------------------------------------------------------------- #
+# Internal helpers                                                             #
+# --------------------------------------------------------------------------- #
+
+
+def _configure_estimation_logging(
+    save_file_log: bool,
+    log_dir: Optional[Union[str, Path]],
+    console_log_level: str,
+    file_log_level: str,
+) -> None:
+    """Configure logging for a cost estimation run."""
+    if save_file_log:
+        current_time = datetime.now().strftime("%Y-%m-%d_%H-%M-%S")
+        log_file_name = f"{SYSTEM_LOG_FILE_PREFIX}cost_estimation_{current_time}{SYSTEM_LOG_FILE_SUFFIX}"
+    else:
+        log_file_name = None
+
+    configure_logging(
+        console_level=console_log_level,
+        file_dir=log_dir,
+        file_name=log_file_name,
+        file_level=file_log_level,
+    )
+
+
+def _build_estimation_delm(
+    config: Union[str, Dict[str, Any], DELMConfig, DELM],
+    data_source: Union[str, Path] | pd.DataFrame,
+) -> DELM:
+    """Create an in-memory DELM instance with preprocessed data for estimation."""
+    if isinstance(config, DELM):
+        config = config.config
+    config_obj = DELMConfig.from_any(config)
+    log.debug(
+        "Config loaded: %s",
+        config_obj.name if hasattr(config_obj, "name") else "unknown",
+    )
+
+    delm = DELM.from_config(
+        config=config_obj,
+        use_disk_storage=False,
+        override_logging=False,
+    )
+    log.debug("DELM instance created for cost estimation")
+
+    delm.prep_data(data_source)
+    log.debug("Data prepared for cost estimation")
+    return delm
+
+
+def _compute_chunk_input_tokens(delm: DELM) -> List[int]:
+    """Compute per-chunk input token counts (system + user prompt + schema JSON)."""
+    extraction_schema = delm.config.schema.schema
+    log.debug("Extraction schema loaded: %s", type(extraction_schema).__name__)
+
+    llm_cfg = delm.config.llm_extraction_cfg
+    system_prompt = llm_cfg.system_prompt
+    user_prompt_template = llm_cfg.prompt_template
+    few_shot_selector = FewShotExampleSelector.from_optional(
+        examples=llm_cfg.few_shot_examples,
+        num_examples=llm_cfg.few_shot_num_examples,
+        truncate_length=llm_cfg.few_shot_truncate_length,
+        random_sample=llm_cfg.few_shot_random_sample,
+    )
+    if few_shot_selector is not None:
+        user_prompt_template = few_shot_selector.inject_into_template(
+            user_prompt_template
+        )
+    variables_text = extraction_schema.get_variables_text()
+    log.debug(
+        "Prompt setup: system_length=%d, template_length=%d, variables_length=%d",
+        len(system_prompt),
+        len(user_prompt_template),
+        len(variables_text),
+    )
+
+    # Precompute the schema overhead once (counts toward prompt tokens)
+    SchemaType = extraction_schema.create_pydantic_schema()
+    schema_text = json.dumps(SchemaType.model_json_schema())
+    log.debug("Computed schema overhead for estimation: %d chars", len(schema_text))
+
+    chunks = delm.experiment_manager.load_preprocessed_data()[
+        SYSTEM_CHUNK_COLUMN
+    ].tolist()
+    log.debug("Processing %d chunks for token estimation", len(chunks))
+
+    chunk_input_tokens: List[int] = []
+    for i, chunk in enumerate(chunks):
+        formatted_prompt = user_prompt_template.format(
+            variables=variables_text, text=chunk
+        )
+        # Include schema JSON for estimation alongside system + user prompt
+        complete_prompt = f"{system_prompt}\n\n{formatted_prompt}\n{schema_text}"
+        chunk_input_tokens.append(delm.cost_tracker.count_tokens(complete_prompt))
+        if i % 100 == 0:  # Log progress every 100 chunks
+            log.debug(
+                "Processed %d/%d chunks, total tokens so far: %d",
+                i + 1,
+                len(chunks),
+                sum(chunk_input_tokens),
+            )
+    return chunk_input_tokens
+
 
 # --------------------------------------------------------------------------- #
 # Cost Estimation Methods                                                     #
@@ -52,82 +161,15 @@ def estimate_input_token_cost(
     Returns:
         Estimated dollar cost of input tokens for processing all chunks.
     """
-    from delm.logging import configure
-    from datetime import datetime
-
-    # Configure logging
-    if save_file_log:
-        current_time = datetime.now().strftime("%Y-%m-%d_%H-%M-%S")
-        log_file_name = f"{SYSTEM_LOG_FILE_PREFIX}cost_estimation_{current_time}{SYSTEM_LOG_FILE_SUFFIX}"
-    else:
-        log_file_name = None
-
-    configure(
-        console_level=console_log_level,
-        file_dir=log_dir,
-        file_name=log_file_name,
-        file_level=file_log_level,
+    _configure_estimation_logging(
+        save_file_log, log_dir, console_log_level, file_log_level
     )
 
     log.debug("Estimating input token cost for data source: %s", data_source)
-    if isinstance(config, DELM):
-        config = config.config
-    config_obj = DELMConfig.from_any(config)
-    log.debug(
-        "Config loaded: %s",
-        config_obj.name if hasattr(config_obj, "name") else "unknown",
-    )
+    delm = _build_estimation_delm(config, data_source)
+    chunk_input_tokens = _compute_chunk_input_tokens(delm)
 
-    delm = DELM.from_config(
-        config=config_obj,
-        use_disk_storage=False,
-        override_logging=False,
-    )
-    log.debug("DELM instance created for cost estimation")
-
-    delm.prep_data(data_source)
-    log.debug("Data prepared for cost estimation")
-
-    extraction_schema = delm.config.schema.schema
-    log.debug("Extraction schema loaded: %s", type(extraction_schema).__name__)
-
-    system_prompt = delm.config.llm_extraction_cfg.system_prompt
-    user_prompt_template = delm.config.llm_extraction_cfg.prompt_template
-    variables_text = extraction_schema.get_variables_text()
-    log.debug(
-        "Prompt setup: system_length=%d, template_length=%d, variables_length=%d",
-        len(system_prompt),
-        len(user_prompt_template),
-        len(variables_text),
-    )
-
-    # Precompute the schema overhead once (counts toward prompt tokens)
-    SchemaType = extraction_schema.create_pydantic_schema()
-    schema_text = json.dumps(SchemaType.model_json_schema())
-    log.debug("Computed schema overhead for estimation: %d chars", len(schema_text))
-
-    total_input_tokens = 0
-    chunks = delm.experiment_manager.load_preprocessed_data()[
-        SYSTEM_CHUNK_COLUMN
-    ].tolist()
-    log.debug("Processing %d chunks for token estimation", len(chunks))
-
-    for i, chunk in enumerate(chunks):
-        formatted_prompt = user_prompt_template.format(
-            variables=variables_text, text=chunk
-        )
-        # Include schema JSON for estimation alongside system + user prompt
-        complete_prompt = f"{system_prompt}\n\n{formatted_prompt}\n{schema_text}"
-        prompt_tokens = delm.cost_tracker.count_tokens(complete_prompt)
-        total_input_tokens += prompt_tokens
-        if i % 100 == 0:  # Log progress every 100 chunks
-            log.debug(
-                "Processed %d/%d chunks, total tokens so far: %d",
-                i + 1,
-                len(chunks),
-                total_input_tokens,
-            )
-
+    total_input_tokens = sum(chunk_input_tokens)
     input_price_per_1M = delm.cost_tracker.model_input_cost_per_1M_tokens
     total_cost = total_input_tokens * input_price_per_1M / 1_000_000
 
@@ -137,6 +179,97 @@ def estimate_input_token_cost(
         total_cost,
     )
     return total_cost
+
+
+def estimate_max_total_cost(
+    config: Union[str, Dict[str, Any], DELMConfig, DELM],
+    data_source: Union[str, Path] | pd.DataFrame,
+    save_file_log: bool = False,
+    log_dir: Optional[Union[str, Path]] = Path(".delm/logs/cost_estimation"),
+    console_log_level: str = "INFO",
+    file_log_level: str = "DEBUG",
+) -> float:
+    """Estimate an upper bound on the total cost without API calls.
+
+    For each chunk the output tokens are bounded by
+    ``min(max_completion_tokens, context_window - input_tokens)``, so the
+    upper bound of the cost is::
+
+        input_price * input_tokens + output_price * min(
+            max_completion_tokens, context_window - input_tokens
+        )
+
+    The model's context window and maximum output tokens are looked up from
+    the tokencost database. When they are unavailable (e.g. a custom model
+    with manual price overrides), the bound falls back to
+    ``max_completion_tokens`` alone.
+
+    Args:
+        config: Configuration for the DELM pipeline (config path | dict | ``DELMConfig``).
+        data_source: Source data for extraction (path or DataFrame).
+        save_file_log: Whether to write a rotating log file.
+        log_dir: Directory for log files when ``save_file_log`` is True.
+        console_log_level: Log level for console output.
+        file_log_level: Log level for file output.
+
+    Returns:
+        Upper-bound dollar cost for processing all chunks.
+    """
+    _configure_estimation_logging(
+        save_file_log, log_dir, console_log_level, file_log_level
+    )
+
+    log.debug("Estimating max total cost for data source: %s", data_source)
+    delm = _build_estimation_delm(config, data_source)
+    chunk_input_tokens = _compute_chunk_input_tokens(delm)
+
+    llm_cfg = delm.config.llm_extraction_cfg
+    max_completion_tokens = llm_cfg.max_completion_tokens
+
+    try:
+        context_window, model_max_output_tokens = get_model_token_limits(
+            llm_cfg.provider, llm_cfg.model
+        )
+    except ValueError:
+        log.warning(
+            "Token limits for %s/%s not found in tokencost database; "
+            "upper bound uses max_completion_tokens=%d only",
+            llm_cfg.provider,
+            llm_cfg.model,
+            max_completion_tokens,
+        )
+        context_window, model_max_output_tokens = None, None
+
+    output_token_cap = max_completion_tokens
+    if model_max_output_tokens is not None:
+        output_token_cap = min(output_token_cap, model_max_output_tokens)
+
+    total_input_tokens = 0
+    total_max_output_tokens = 0
+    for input_tokens in chunk_input_tokens:
+        chunk_output_bound = output_token_cap
+        if context_window is not None:
+            chunk_output_bound = min(
+                chunk_output_bound, max(context_window - input_tokens, 0)
+            )
+        total_input_tokens += input_tokens
+        total_max_output_tokens += chunk_output_bound
+
+    input_price_per_1M = delm.cost_tracker.model_input_cost_per_1M_tokens
+    output_price_per_1M = delm.cost_tracker.model_output_cost_per_1M_tokens
+    max_total_cost = (
+        total_input_tokens * input_price_per_1M
+        + total_max_output_tokens * output_price_per_1M
+    ) / 1_000_000
+
+    log.debug(
+        "Max total cost estimation completed: %d input tokens, "
+        "%d max output tokens, $%.6f upper bound",
+        total_input_tokens,
+        total_max_output_tokens,
+        max_total_cost,
+    )
+    return max_total_cost
 
 
 def estimate_total_cost(
@@ -162,21 +295,8 @@ def estimate_total_cost(
     Returns:
         Estimated dollar cost for processing the entire dataset, scaled from the sample.
     """
-    from delm.logging import configure
-    from datetime import datetime
-
-    # Configure logging
-    if save_file_log:
-        current_time = datetime.now().strftime("%Y-%m-%d_%H-%M-%S")
-        log_file_name = f"{SYSTEM_LOG_FILE_PREFIX}cost_estimation_{current_time}{SYSTEM_LOG_FILE_SUFFIX}"
-    else:
-        log_file_name = None
-
-    configure(
-        console_level=console_log_level,
-        file_dir=log_dir,
-        file_name=log_file_name,
-        file_level=file_log_level,
+    _configure_estimation_logging(
+        save_file_log, log_dir, console_log_level, file_log_level
     )
 
     log.warning(

--- a/src/delm/utils/cost_estimation.py
+++ b/src/delm/utils/cost_estimation.py
@@ -19,6 +19,7 @@ from delm.delm import DELM
 from delm.constants import (
     SYSTEM_CHUNK_COLUMN,
     SYSTEM_RANDOM_SEED,
+    SYSTEM_RECORD_ID_COLUMN,
     SYSTEM_LOG_FILE_PREFIX,
     SYSTEM_LOG_FILE_SUFFIX,
 )
@@ -81,8 +82,19 @@ def _build_estimation_delm(
     return delm
 
 
-def _compute_chunk_input_tokens(delm: DELM) -> List[int]:
-    """Compute per-chunk input token counts (system + user prompt + schema JSON)."""
+def _compute_chunk_input_tokens(
+    delm: DELM, chunks: Optional[List[str]] = None
+) -> List[int]:
+    """Compute per-chunk input token counts (system + user prompt + schema JSON).
+
+    Args:
+        delm: DELM instance with a cost tracker.
+        chunks: Text chunks to count tokens for. When None, chunks are loaded
+            from the experiment manager's preprocessed data.
+
+    Returns:
+        Per-chunk token counts of the complete prompt.
+    """
     extraction_schema = delm.config.schema.schema
     log.debug("Extraction schema loaded: %s", type(extraction_schema).__name__)
 
@@ -112,9 +124,10 @@ def _compute_chunk_input_tokens(delm: DELM) -> List[int]:
     schema_text = json.dumps(SchemaType.model_json_schema())
     log.debug("Computed schema overhead for estimation: %d chars", len(schema_text))
 
-    chunks = delm.experiment_manager.load_preprocessed_data()[
-        SYSTEM_CHUNK_COLUMN
-    ].tolist()
+    if chunks is None:
+        chunks = delm.experiment_manager.load_preprocessed_data()[
+            SYSTEM_CHUNK_COLUMN
+        ].tolist()
     log.debug("Processing %d chunks for token estimation", len(chunks))
 
     chunk_input_tokens: List[int] = []
@@ -283,6 +296,10 @@ def estimate_total_cost(
 ) -> float:
     """Estimate total cost using API calls on a sample of the data.
 
+    The sampled cost is extrapolated by input-token share rather than record
+    count, so datasets with uneven record lengths do not bias the estimate:
+    ``total = sample_cost * total_input_tokens / sample_input_tokens``.
+
     Args:
         config: Configuration for the DELM pipeline (config path | dict | ``DELMConfig``).
         data_source: Source data for extraction (path or DataFrame).
@@ -294,6 +311,10 @@ def estimate_total_cost(
 
     Returns:
         Estimated dollar cost for processing the entire dataset, scaled from the sample.
+
+    Raises:
+        ValueError: If the sampled records produce no chunks (e.g. everything
+            is removed by the score filter).
     """
     _configure_estimation_logging(
         save_file_log, log_dir, console_log_level, file_log_level
@@ -329,13 +350,34 @@ def estimate_total_cost(
     total_records = len(records_df)
     log.debug("Loaded %d total records from data source", total_records)
 
-    sample_records_df = records_df.sample(
+    sample_record_ids = records_df.sample(
         n=sample_size, random_state=SYSTEM_RANDOM_SEED
-    )
-    log.debug("Sampled %d records for cost estimation", len(sample_records_df))
+    )[SYSTEM_RECORD_ID_COLUMN]
+    log.debug("Sampled %d records for cost estimation", len(sample_record_ids))
 
-    sample_chunks_df = delm.data_processor.process_dataframe(sample_records_df)
-    log.debug("Processed sample records into %d chunks", len(sample_chunks_df))
+    all_chunks_df = delm.data_processor.process_dataframe(records_df)
+    sample_chunks_df = all_chunks_df[
+        all_chunks_df[SYSTEM_RECORD_ID_COLUMN].isin(sample_record_ids)
+    ]
+    log.debug(
+        "Processed data into %d chunks (%d in sample)",
+        len(all_chunks_df),
+        len(sample_chunks_df),
+    )
+
+    total_input_tokens = sum(
+        _compute_chunk_input_tokens(delm, all_chunks_df[SYSTEM_CHUNK_COLUMN].tolist())
+    )
+    sample_input_tokens = sum(
+        _compute_chunk_input_tokens(
+            delm, sample_chunks_df[SYSTEM_CHUNK_COLUMN].tolist()
+        )
+    )
+    if sample_input_tokens == 0:
+        raise ValueError(
+            "Sampled records produced no chunks to process; cannot extrapolate "
+            "cost. Increase sample_size or relax the score filter."
+        )
 
     delm.experiment_manager.save_preprocessed_data(sample_chunks_df)
     log.debug("Saved preprocessed sample data")
@@ -345,11 +387,14 @@ def estimate_total_cost(
     log.debug("LLM processing completed")
 
     sample_cost = delm.cost_tracker.get_current_cost()
-    total_estimated_cost = sample_cost * (total_records / sample_size)
+    total_estimated_cost = sample_cost * (total_input_tokens / sample_input_tokens)
 
     log.debug(
-        "Total cost estimation completed: sample_cost=$%.6f, total_estimated_cost=$%.6f",
+        "Total cost estimation completed: sample_cost=$%.6f (%d/%d input tokens), "
+        "total_estimated_cost=$%.6f",
         sample_cost,
+        sample_input_tokens,
+        total_input_tokens,
         total_estimated_cost,
     )
     return total_estimated_cost

--- a/src/delm/utils/cost_estimation.py
+++ b/src/delm/utils/cost_estimation.py
@@ -107,10 +107,6 @@ def _compute_chunk_input_tokens(
         truncate_length=llm_cfg.few_shot_truncate_length,
         random_sample=llm_cfg.few_shot_random_sample,
     )
-    if few_shot_selector is not None:
-        user_prompt_template = few_shot_selector.inject_into_template(
-            user_prompt_template
-        )
     variables_text = extraction_schema.get_variables_text()
     log.debug(
         "Prompt setup: system_length=%d, template_length=%d, variables_length=%d",
@@ -135,6 +131,8 @@ def _compute_chunk_input_tokens(
         formatted_prompt = user_prompt_template.format(
             variables=variables_text, text=chunk
         )
+        if few_shot_selector is not None:
+            formatted_prompt = few_shot_selector.prepend_to_prompt(formatted_prompt)
         # Include schema JSON for estimation alongside system + user prompt
         complete_prompt = f"{system_prompt}\n\n{formatted_prompt}\n{schema_text}"
         chunk_input_tokens.append(delm.cost_tracker.count_tokens(complete_prompt))

--- a/src/delm/utils/cost_tracker.py
+++ b/src/delm/utils/cost_tracker.py
@@ -11,6 +11,26 @@ from pydantic import BaseModel
 log = logging.getLogger(__name__)
 
 
+def get_tokenizer_for_model(model: str) -> tiktoken.Encoding:
+    """Return the tiktoken encoding for a model, falling back to cl100k_base.
+
+    Args:
+        model: The model name (e.g. "gpt-4o-mini").
+
+    Returns:
+        The tiktoken encoding registered for the model, or ``cl100k_base``
+        when the model is unknown to tiktoken.
+    """
+    try:
+        return tiktoken.encoding_for_model(model)
+    except KeyError:
+        log.debug(
+            "No tiktoken encoding registered for model '%s'; using cl100k_base",
+            model,
+        )
+        return tiktoken.get_encoding("cl100k_base")
+
+
 class CostTracker:
     """Track tokens and estimate cost for an extraction run."""
 
@@ -26,7 +46,7 @@ class CostTracker:
         log.debug("Initializing cost tracker for %s/%s", provider, model)
         self.provider = provider
         self.model = model
-        self.tokenizer = tiktoken.get_encoding("cl100k_base")
+        self.tokenizer = get_tokenizer_for_model(model)
         self.model_input_cost_per_1M_tokens = (
             model_input_cost_per_1M_tokens
             if model_input_cost_per_1M_tokens is not None
@@ -176,7 +196,7 @@ class CostTracker:
         obj = cls.__new__(cls)
         obj.provider = d["provider"]
         obj.model = d["model"]
-        obj.tokenizer = tiktoken.get_encoding("cl100k_base")
+        obj.tokenizer = get_tokenizer_for_model(obj.model)
         obj.model_input_cost_per_1M_tokens = d.get(
             "model_input_cost_per_1M_tokens", 0.0
         )

--- a/src/delm/utils/cost_tracker.py
+++ b/src/delm/utils/cost_tracker.py
@@ -1,6 +1,7 @@
 """Token counting and cost tracking utilities for DELM."""
 
 import logging
+import threading
 import tiktoken
 import json
 from delm.utils.model_price_database import get_model_token_price
@@ -61,6 +62,8 @@ class CostTracker:
         self.output_tokens = 0
         self.count_cache_hits_towards_cost = count_cache_hits_towards_cost
         self.max_budget = max_budget
+        self.reserved_cost = 0.0
+        self._reservation_lock = threading.Lock()
 
         log.debug(
             "Cost tracker initialized - input: $%.6f/1M tokens, output: $%.6f/1M tokens",
@@ -77,6 +80,65 @@ class CostTracker:
         if is_over:
             log.warning("Budget exceeded: $%.4f > $%.4f", current_cost, self.max_budget)
         return is_over
+
+    def try_reserve_budget(
+        self, input_tokens: int, output_tokens: int
+    ) -> Optional[float]:
+        """Reserve the estimated cost of a request against the budget.
+
+        With concurrent workers, checking the budget only after responses
+        arrive can overshoot ``max_budget`` by a full batch of in-flight
+        requests. Reserving the worst-case cost of each request before
+        dispatch enforces the budget strictly.
+
+        Args:
+            input_tokens: Estimated input tokens for the request.
+            output_tokens: Upper bound on output tokens (e.g. ``max_completion_tokens``).
+
+        Returns:
+            The reserved dollar amount to later pass to
+            ``release_budget_reservation``, or None when the reservation would
+            exceed ``max_budget``. When no budget is set, returns 0.0 and
+            tracks nothing.
+        """
+        if self.max_budget is None:
+            return 0.0
+        estimated_cost = self.estimate_cost(input_tokens, output_tokens)
+        with self._reservation_lock:
+            projected = self.get_current_cost() + self.reserved_cost + estimated_cost
+            if projected > self.max_budget:
+                log.warning(
+                    "Budget reservation denied: projected $%.4f > budget $%.4f",
+                    projected,
+                    self.max_budget,
+                )
+                return None
+            self.reserved_cost += estimated_cost
+        log.debug(
+            "Reserved $%.6f against budget (total reserved: $%.6f)",
+            estimated_cost,
+            self.reserved_cost,
+        )
+        return estimated_cost
+
+    def release_budget_reservation(self, reserved_cost: float) -> None:
+        """Release a reservation made by ``try_reserve_budget``.
+
+        Call after the request settles (actual usage is tracked separately
+        via ``track_token_usage``).
+
+        Args:
+            reserved_cost: The amount returned by ``try_reserve_budget``.
+        """
+        if self.max_budget is None or reserved_cost == 0.0:
+            return
+        with self._reservation_lock:
+            self.reserved_cost = max(0.0, self.reserved_cost - reserved_cost)
+        log.debug(
+            "Released $%.6f budget reservation (total reserved: $%.6f)",
+            reserved_cost,
+            self.reserved_cost,
+        )
 
     def track_input_text(self, *parts: Any) -> None:
         """Accumulate input tokens for one or more parts.
@@ -207,6 +269,8 @@ class CostTracker:
         obj.output_tokens = d.get("output_tokens", 0)
         obj.count_cache_hits_towards_cost = False  # Default value
         obj.max_budget = d.get("max_budget", None)
+        obj.reserved_cost = 0.0
+        obj._reservation_lock = threading.Lock()
         log.debug(
             "CostTracker restored from dict: provider=%s, model=%s, input_tokens=%d, output_tokens=%d",
             obj.provider,

--- a/src/delm/utils/few_shot.py
+++ b/src/delm/utils/few_shot.py
@@ -1,0 +1,177 @@
+"""Few-shot example selection and prompt injection for DELM.
+
+Renders hand-labeled examples into the extraction prompt. Supports limiting
+the number of examples, truncating example text to a token budget, and
+random sampling from the provided ground-truth pool.
+"""
+
+import json
+import logging
+import random
+from typing import Any, Dict, List, Optional
+
+import tiktoken
+
+from delm.constants import SYSTEM_RANDOM_SEED
+
+log = logging.getLogger(__name__)
+
+FEW_SHOT_PLACEHOLDER = "{examples}"
+
+
+class FewShotExampleSelector:
+    """Select and render few-shot examples for extraction prompts.
+
+    Each example is a mapping with a ``"text"`` key (source text) and an
+    ``"output"`` key (expected extraction result as a dict or JSON string).
+    """
+
+    def __init__(
+        self,
+        examples: List[Dict[str, Any]],
+        num_examples: int,
+        truncate_length: Optional[int] = None,
+        random_sample: bool = False,
+        seed: int = SYSTEM_RANDOM_SEED,
+    ) -> None:
+        """Initialize the selector.
+
+        Args:
+            examples: Pool of ground-truth examples, each with ``"text"`` and
+                ``"output"`` keys.
+            num_examples: Number of examples to include per prompt. Capped at
+                the pool size.
+            truncate_length: Maximum token length for each example's text.
+                ``None`` disables truncation.
+            random_sample: Whether to randomly sample examples from the pool
+                for each prompt. When False, the first ``num_examples``
+                examples are always used.
+            seed: Seed for the sampling RNG (reproducible across runs).
+        """
+        validate_few_shot_params(examples, num_examples, truncate_length)
+
+        self.examples = examples
+        self.num_examples = min(num_examples, len(examples))
+        if self.num_examples < num_examples:
+            log.warning(
+                "Requested %d few-shot examples but only %d available; using %d",
+                num_examples,
+                len(examples),
+                self.num_examples,
+            )
+        self.truncate_length = truncate_length
+        self.random_sample = random_sample
+        self._rng = random.Random(seed)
+        self._tokenizer = tiktoken.get_encoding("cl100k_base")
+
+    @classmethod
+    def from_optional(
+        cls,
+        examples: Optional[List[Dict[str, Any]]],
+        num_examples: int,
+        truncate_length: Optional[int],
+        random_sample: bool,
+    ) -> Optional["FewShotExampleSelector"]:
+        """Build a selector, or return None when no examples are configured."""
+        if examples is None:
+            return None
+        return cls(
+            examples=examples,
+            num_examples=num_examples,
+            truncate_length=truncate_length,
+            random_sample=random_sample,
+        )
+
+    def select_examples(self) -> List[Dict[str, Any]]:
+        """Return the examples to include in the next prompt."""
+        if self.random_sample:
+            return self._rng.sample(self.examples, self.num_examples)
+        return self.examples[: self.num_examples]
+
+    def build_examples_block(self) -> str:
+        """Render the selected examples as a text block for the prompt."""
+        lines: List[str] = ["Examples:"]
+        for i, example in enumerate(self.select_examples(), start=1):
+            text = self._truncate(str(example["text"]))
+            output = example["output"]
+            output_json = output if isinstance(output, str) else json.dumps(output)
+            lines.append(f"\nExample {i}:")
+            lines.append(f"Text: {text}")
+            lines.append(f"Output: {output_json}")
+        return "\n".join(lines)
+
+    def inject_into_template(self, prompt_template: str) -> str:
+        """Insert the rendered examples block into a prompt template.
+
+        If the template contains the ``{examples}`` placeholder, it is
+        replaced in place; otherwise the block is prepended to the template.
+        Braces inside the examples (e.g. JSON outputs) are escaped so the
+        template can still be passed through ``str.format``.
+
+        Args:
+            prompt_template: Extraction prompt template with ``{variables}``
+                and ``{text}`` placeholders.
+
+        Returns:
+            The template with the examples block included.
+        """
+        examples_block = (
+            self.build_examples_block().replace("{", "{{").replace("}", "}}")
+        )
+        if FEW_SHOT_PLACEHOLDER in prompt_template:
+            return prompt_template.replace(FEW_SHOT_PLACEHOLDER, examples_block)
+        return f"{examples_block}\n\n{prompt_template}"
+
+    def _truncate(self, text: str) -> str:
+        if self.truncate_length is None:
+            return text
+        tokens = self._tokenizer.encode(text)
+        if len(tokens) <= self.truncate_length:
+            return text
+        return self._tokenizer.decode(tokens[: self.truncate_length])
+
+
+def validate_few_shot_params(
+    examples: List[Dict[str, Any]],
+    num_examples: int,
+    truncate_length: Optional[int],
+) -> None:
+    """Validate few-shot configuration values.
+
+    Args:
+        examples: Pool of ground-truth examples.
+        num_examples: Number of examples to include per prompt.
+        truncate_length: Maximum token length per example text or None.
+
+    Raises:
+        ValueError: If any parameter is invalid.
+    """
+    if not isinstance(examples, list) or not examples:
+        raise ValueError(
+            f"few_shot_examples must be a non-empty list of dicts. "
+            f"few_shot_examples: {examples}"
+        )
+    for i, example in enumerate(examples):
+        if not isinstance(example, dict):
+            raise ValueError(
+                f"few_shot_examples[{i}] must be a dict with 'text' and 'output' "
+                f"keys, got {type(example).__name__}"
+            )
+        missing = {"text", "output"} - set(example)
+        if missing:
+            raise ValueError(
+                f"few_shot_examples[{i}] is missing keys: {sorted(missing)}. "
+                f"Each example needs 'text' and 'output'."
+            )
+    if not isinstance(num_examples, int) or num_examples <= 0:
+        raise ValueError(
+            f"few_shot_num_examples must be a positive integer. "
+            f"few_shot_num_examples: {num_examples}"
+        )
+    if truncate_length is not None and (
+        not isinstance(truncate_length, int) or truncate_length <= 0
+    ):
+        raise ValueError(
+            f"few_shot_truncate_length must be a positive integer or None. "
+            f"few_shot_truncate_length: {truncate_length}"
+        )

--- a/src/delm/utils/few_shot.py
+++ b/src/delm/utils/few_shot.py
@@ -3,6 +3,11 @@
 Renders hand-labeled examples into the extraction prompt. Supports limiting
 the number of examples, truncating example text to a token budget, and
 random sampling from the provided ground-truth pool.
+
+The examples block is prepended once to the final prompt (after template
+formatting) rather than injected into the template. MultipleSchema reuses
+the template for every sub-schema section, so template-level injection
+would duplicate the block per section.
 """
 
 import json
@@ -15,8 +20,6 @@ import tiktoken
 from delm.constants import SYSTEM_RANDOM_SEED
 
 log = logging.getLogger(__name__)
-
-FEW_SHOT_PLACEHOLDER = "{examples}"
 
 
 class FewShotExampleSelector:
@@ -100,27 +103,16 @@ class FewShotExampleSelector:
             lines.append(f"Output: {output_json}")
         return "\n".join(lines)
 
-    def inject_into_template(self, prompt_template: str) -> str:
-        """Insert the rendered examples block into a prompt template.
-
-        If the template contains the ``{examples}`` placeholder, it is
-        replaced in place; otherwise the block is prepended to the template.
-        Braces inside the examples (e.g. JSON outputs) are escaped so the
-        template can still be passed through ``str.format``.
+    def prepend_to_prompt(self, prompt: str) -> str:
+        """Prepend the rendered examples block to a fully formatted prompt.
 
         Args:
-            prompt_template: Extraction prompt template with ``{variables}``
-                and ``{text}`` placeholders.
+            prompt: The final extraction prompt (after template formatting).
 
         Returns:
-            The template with the examples block included.
+            The prompt with the examples block prepended once.
         """
-        examples_block = (
-            self.build_examples_block().replace("{", "{{").replace("}", "}}")
-        )
-        if FEW_SHOT_PLACEHOLDER in prompt_template:
-            return prompt_template.replace(FEW_SHOT_PLACEHOLDER, examples_block)
-        return f"{examples_block}\n\n{prompt_template}"
+        return f"{self.build_examples_block()}\n\n{prompt}"
 
     def _truncate(self, text: str) -> str:
         if self.truncate_length is None:

--- a/src/delm/utils/model_price_database.py
+++ b/src/delm/utils/model_price_database.py
@@ -1,15 +1,57 @@
 """Model pricing lookup via the ``tokencost`` package.
 
 Delegates all price resolution to tokencost's maintained database of 400+ models.
+If a model is missing from the bundled database, the live price feed is fetched
+once per process before giving up, so newly released models resolve automatically.
 """
 
 import logging
-from typing import Tuple
+import threading
+from typing import Any, Dict, Optional, Tuple
 
+from tokencost import refresh_prices
 from tokencost.constants import TOKEN_COSTS
 from tokencost.costs import _normalize_model_for_pricing
 
 log = logging.getLogger(__name__)
+
+_REFRESH_LOCK = threading.Lock()
+_PRICES_REFRESHED = False
+
+
+def _find_entry(provider: str, model: str) -> Optional[Dict[str, Any]]:
+    """Look up a tokencost entry, trying ``provider/model`` then bare ``model``."""
+    candidates = [
+        f"{provider}/{model}",
+        model,
+    ]
+    for candidate in candidates:
+        normalized = _normalize_model_for_pricing(candidate)
+        if normalized in TOKEN_COSTS:
+            return TOKEN_COSTS[normalized]
+    return None
+
+
+def _find_entry_with_refresh(provider: str, model: str) -> Optional[Dict[str, Any]]:
+    """Look up a tokencost entry, refreshing the live price feed once on a miss."""
+    global _PRICES_REFRESHED
+
+    entry = _find_entry(provider, model)
+    if entry is not None:
+        return entry
+
+    with _REFRESH_LOCK:
+        if not _PRICES_REFRESHED:
+            log.info(
+                "Model '%s/%s' not in bundled tokencost database; "
+                "refreshing prices from the live feed",
+                provider,
+                model,
+            )
+            refresh_prices(write_file=False)
+            _PRICES_REFRESHED = True
+
+    return _find_entry(provider, model)
 
 
 def get_model_token_price(provider: str, model: str) -> Tuple[float, float]:
@@ -17,6 +59,8 @@ def get_model_token_price(provider: str, model: str) -> Tuple[float, float]:
     Look up the price per 1M input/output tokens for a given provider and model.
 
     Tries ``provider/model`` first (litellm convention), then bare ``model``.
+    If the model is missing from the bundled database, the live price feed is
+    fetched once per process and the lookup is retried.
 
     Args:
         provider: The provider of the model (e.g. "openai", "anthropic").
@@ -30,27 +74,21 @@ def get_model_token_price(provider: str, model: str) -> Tuple[float, float]:
     """
     log.debug("Looking up price for provider='%s', model='%s'", provider, model)
 
-    candidates = [
-        f"{provider}/{model}",
-        model,
-    ]
-
-    for candidate in candidates:
-        normalized = _normalize_model_for_pricing(candidate)
-        if normalized in TOKEN_COSTS:
-            entry = TOKEN_COSTS[normalized]
-            input_per_token = entry.get("input_cost_per_token", 0.0)
-            output_per_token = entry.get("output_cost_per_token", 0.0)
-            # tokencost stores cost-per-token; convert to cost-per-1M-tokens
-            input_per_1m = float(input_per_token) * 1_000_000
-            output_per_1m = float(output_per_token) * 1_000_000
-            log.debug(
-                "Found price for '%s': input=$%.4f/1M, output=$%.4f/1M",
-                candidate,
-                input_per_1m,
-                output_per_1m,
-            )
-            return input_per_1m, output_per_1m
+    entry = _find_entry_with_refresh(provider, model)
+    if entry is not None:
+        input_per_token = entry.get("input_cost_per_token", 0.0)
+        output_per_token = entry.get("output_cost_per_token", 0.0)
+        # tokencost stores cost-per-token; convert to cost-per-1M-tokens
+        input_per_1m = float(input_per_token) * 1_000_000
+        output_per_1m = float(output_per_token) * 1_000_000
+        log.debug(
+            "Found price for '%s/%s': input=$%.4f/1M, output=$%.4f/1M",
+            provider,
+            model,
+            input_per_1m,
+            output_per_1m,
+        )
+        return input_per_1m, output_per_1m
 
     log.error(
         "Model '%s' not found in tokencost database for provider '%s'",
@@ -61,4 +99,38 @@ def get_model_token_price(provider: str, model: str) -> Tuple[float, float]:
         f"Model {model} not found in tokencost database for provider {provider}. "
         f"Set model_input_cost_per_1M_tokens and model_output_cost_per_1M_tokens manually, "
         f"or register the model via tokencost.configure_model()."
+    )
+
+
+def get_model_token_limits(
+    provider: str, model: str
+) -> Tuple[Optional[int], Optional[int]]:
+    """
+    Look up the input/output token limits for a given provider and model.
+
+    Args:
+        provider: The provider of the model (e.g. "openai", "anthropic").
+        model: The name of the model (e.g. "gpt-4o-mini").
+
+    Returns:
+        (max_input_tokens, max_output_tokens): tuple of optional ints. Either
+        value is None when tokencost does not report the corresponding limit.
+
+    Raises:
+        ValueError: If the model is not found in the tokencost database.
+    """
+    log.debug("Looking up token limits for provider='%s', model='%s'", provider, model)
+
+    entry = _find_entry_with_refresh(provider, model)
+    if entry is None:
+        raise ValueError(
+            f"Model {model} not found in tokencost database for provider {provider}. "
+            f"Register the model via tokencost.configure_model()."
+        )
+
+    max_input_tokens = entry.get("max_input_tokens")
+    max_output_tokens = entry.get("max_output_tokens", entry.get("max_tokens"))
+    return (
+        int(max_input_tokens) if max_input_tokens is not None else None,
+        int(max_output_tokens) if max_output_tokens is not None else None,
     )

--- a/src/delm/utils/post_processing.py
+++ b/src/delm/utils/post_processing.py
@@ -188,8 +188,16 @@ def merge_jsons_for_record(json_list: List[Dict[str, Any]], schema: ExtractionSc
             for json_item in json_list:
                 if json_item is None:
                     continue
+                if isinstance(json_item, str):
+                    try:
+                        json_item = json.loads(json_item)
+                    except json.JSONDecodeError:
+                        continue
+                if not isinstance(json_item, dict):
+                    continue
                 if sub_schema_type == "simpleschema":
-                    sub_jsons.append(json_item[sub_schema_spec_name])
+                    if sub_schema_spec_name in json_item:
+                        sub_jsons.append(json_item[sub_schema_spec_name])
                 elif sub_schema_type == "nestedschema":
                     nested_json_item = {}
                     if sub_schema_spec_name in json_item:
@@ -289,8 +297,8 @@ def explode_json_results(
 
     for idx, row in df.iterrows():
         json_data = row[json_column]
-        row_has_errors = (
-            SYSTEM_ERRORS_COLUMN in row.index and pd.notna(row[SYSTEM_ERRORS_COLUMN])
+        row_has_errors = SYSTEM_ERRORS_COLUMN in row.index and pd.notna(
+            row[SYSTEM_ERRORS_COLUMN]
         )
         if row_has_errors:
             continue

--- a/src/delm/utils/post_processing.py
+++ b/src/delm/utils/post_processing.py
@@ -73,9 +73,16 @@ def merge_jsons_for_record(json_list: List[Dict[str, Any]], schema: ExtractionSc
     if not json_list:
         log.debug("Empty JSON list, using empty list")
         json_list = []
+    json_list = [j for j in json_list if j is not None]
     if json_list and isinstance(json_list[0], str):
         log.debug("Converting %d JSON strings to dicts", len(json_list))
-        json_list = [json.loads(j) for j in json_list]  # type: ignore
+        parsed: List[Any] = []
+        for j in json_list:
+            try:
+                parsed.append(json.loads(j))
+            except (json.JSONDecodeError, TypeError):
+                continue
+        json_list = parsed
 
     schema_type = getattr(schema, "schema_type", type(schema).__name__).lower()
     log.debug("Schema type: %s", schema_type)
@@ -88,6 +95,15 @@ def merge_jsons_for_record(json_list: List[Dict[str, Any]], schema: ExtractionSc
             log.debug("Processing variable: %s", schema_var.name)
             bucket: List[Any] = []
             for json_item in json_list:
+                if json_item is None:
+                    continue
+                if isinstance(json_item, str):
+                    try:
+                        json_item = json.loads(json_item)
+                    except json.JSONDecodeError:
+                        continue
+                if not isinstance(json_item, dict):
+                    continue
                 val = json_item.get(schema_var.name)
                 if val is None:
                     continue
@@ -127,6 +143,15 @@ def merge_jsons_for_record(json_list: List[Dict[str, Any]], schema: ExtractionSc
         log.debug("Processing NestedSchema with container: %s", nested_container_name)
         merged_nested: List[Dict[str, Any]] = []
         for json_item in json_list:
+            if json_item is None:
+                continue
+            if isinstance(json_item, str):
+                try:
+                    json_item = json.loads(json_item)
+                except json.JSONDecodeError:
+                    continue
+            if not isinstance(json_item, dict):
+                continue
             items = json_item.get(nested_container_name, [])
             if items:
                 log.debug(
@@ -161,6 +186,8 @@ def merge_jsons_for_record(json_list: List[Dict[str, Any]], schema: ExtractionSc
 
             sub_jsons = []
             for json_item in json_list:
+                if json_item is None:
+                    continue
                 if sub_schema_type == "simpleschema":
                     sub_jsons.append(json_item[sub_schema_spec_name])
                 elif sub_schema_type == "nestedschema":

--- a/tests/unit/api_kwargs/test_api_kwargs.py
+++ b/tests/unit/api_kwargs/test_api_kwargs.py
@@ -11,6 +11,7 @@ from unittest.mock import patch, MagicMock
 from delm import DELM, Schema, DELMConfig
 from delm.config import LLMExtractionConfig
 from delm.models import ExtractionVariable
+from delm.utils.cost_tracker import get_tokenizer_for_model
 
 
 @pytest.fixture
@@ -155,6 +156,7 @@ class TestApiKwargsExtractionManager:
             manager.prompt_template = model_config.prompt_template
             manager.system_prompt = model_config.system_prompt
             manager.few_shot_selector = None
+            manager.tokenizer = get_tokenizer_for_model(model_config.model)
             manager.cost_tracker = None
             manager.semantic_cache = mock_cache
             manager.rate_limiter = mock_rate_limiter

--- a/tests/unit/api_kwargs/test_api_kwargs.py
+++ b/tests/unit/api_kwargs/test_api_kwargs.py
@@ -52,6 +52,21 @@ class TestApiKwargsConfig:
         restored = DELMConfig.from_dict(config_dict)
         assert restored.llm_extraction_cfg.api_kwargs == kwargs
 
+    def test_from_dict_uses_defaults_for_missing_optional_fields(self, simple_schema):
+        config = DELMConfig(schema=simple_schema)
+        config_dict = config.to_dict()
+
+        del config_dict["base_url"]
+        del config_dict["mode"]
+        del config_dict["api_kwargs"]
+        del config_dict["rate_limit_period_seconds"]
+
+        restored = DELMConfig.from_dict(config_dict)
+        assert restored.llm_extraction_cfg.base_url is None
+        assert restored.llm_extraction_cfg.mode is None
+        assert restored.llm_extraction_cfg.api_kwargs == {}
+        assert restored.llm_extraction_cfg.rate_limit_period_seconds == 60.0
+
     def test_api_kwargs_validation_rejects_non_dict(self, simple_schema):
         config = DELMConfig(schema=simple_schema, api_kwargs={"valid": True})
         config.llm_extraction_cfg.api_kwargs = "not_a_dict"

--- a/tests/unit/api_kwargs/test_api_kwargs.py
+++ b/tests/unit/api_kwargs/test_api_kwargs.py
@@ -154,6 +154,7 @@ class TestApiKwargsExtractionManager:
             manager.retry_handler = MagicMock()
             manager.prompt_template = model_config.prompt_template
             manager.system_prompt = model_config.system_prompt
+            manager.few_shot_selector = None
             manager.cost_tracker = None
             manager.semantic_cache = mock_cache
             manager.rate_limiter = mock_rate_limiter

--- a/tests/unit/config/test_config.py
+++ b/tests/unit/config/test_config.py
@@ -6,6 +6,9 @@ NOTE: Most tests have been removed during API redesign.
 
 import pytest
 
+from delm import DELMConfig, Schema
+from delm.models import ExtractionVariable
+
 
 # ============================================================================
 # INTERNAL CONFIG CLASSES - TESTS DELETED
@@ -54,3 +57,55 @@ class TestConfigPlaceholder:
     def test_placeholder(self):
         """Placeholder test that always passes."""
         assert True
+
+
+@pytest.fixture
+def schema_dict():
+    schema = Schema.simple(
+        variables_list=[
+            ExtractionVariable(
+                name="test_field",
+                description="A test field",
+                data_type="string",
+            )
+        ]
+    )
+    return schema.to_dict()
+
+
+class TestDELMConfigFromDictForwardCompatibility:
+    """from_dict must tolerate configs saved by older versions (issue #61)."""
+
+    def test_schema_only_dict_uses_constructor_defaults(self, schema_dict):
+        config = DELMConfig.from_dict({"schema": schema_dict})
+        llm_cfg = config.llm_extraction_cfg
+        assert llm_cfg.provider == "openai"
+        assert llm_cfg.model == "gpt-4o-mini"
+        assert llm_cfg.temperature == 0.0
+        assert llm_cfg.track_cost is True
+        assert config.data_preprocessing_cfg.target_column == "text"
+        assert config.semantic_cache_cfg.backend == "sqlite"
+
+    def test_partial_dict_overrides_only_given_keys(self, schema_dict):
+        config = DELMConfig.from_dict(
+            {"schema": schema_dict, "model": "gpt-4o", "temperature": 0.5}
+        )
+        assert config.llm_extraction_cfg.model == "gpt-4o"
+        assert config.llm_extraction_cfg.temperature == 0.5
+        assert config.llm_extraction_cfg.provider == "openai"
+
+    def test_missing_schema_raises_value_error(self):
+        with pytest.raises(ValueError, match="must contain a 'schema' key"):
+            DELMConfig.from_dict({"model": "gpt-4o"})
+
+    def test_unknown_keys_are_ignored(self, schema_dict):
+        config = DELMConfig.from_dict(
+            {"schema": schema_dict, "some_future_field": 123}
+        )
+        assert config.llm_extraction_cfg.model == "gpt-4o-mini"
+
+    def test_full_round_trip_still_works(self, schema_dict):
+        config = DELMConfig.from_dict({"schema": schema_dict, "batch_size": 42})
+        restored = DELMConfig.from_dict(config.to_dict())
+        assert restored.llm_extraction_cfg.batch_size == 42
+        restored.validate()

--- a/tests/unit/cost_estimation/test_cost_estimation.py
+++ b/tests/unit/cost_estimation/test_cost_estimation.py
@@ -1,0 +1,125 @@
+"""
+Unit tests for offline cost estimation, including the upper-bound estimate
+from issue #44. No API calls are made.
+"""
+
+import pandas as pd
+import pytest
+
+from delm import DELMConfig, Schema
+from delm.models import ExtractionVariable
+from delm.utils.cost_estimation import (
+    estimate_input_token_cost,
+    estimate_max_total_cost,
+)
+
+
+@pytest.fixture(autouse=True)
+def fake_openai_api_key(monkeypatch):
+    """Instructor client creation requires a key; no API calls are made."""
+    monkeypatch.setenv("OPENAI_API_KEY", "test-key-no-calls-made")
+
+
+@pytest.fixture
+def simple_schema():
+    return Schema.simple(
+        variables_list=[
+            ExtractionVariable(
+                name="company",
+                description="Company name",
+                data_type="string",
+            )
+        ]
+    )
+
+
+@pytest.fixture
+def report_text_df():
+    return pd.DataFrame(
+        {
+            "text": [
+                "Goldman Sachs expects oil prices to rise.",
+                "Morgan Stanley cut its gas price forecast.",
+                "JP Morgan sees steel demand growing 8%.",
+            ]
+        }
+    )
+
+
+def _make_config(simple_schema, **overrides):
+    defaults = {
+        "schema": simple_schema,
+        "provider": "openai",
+        "model": "gpt-4o-mini",
+        "cache_backend": None,
+    }
+    defaults.update(overrides)
+    return DELMConfig(**defaults)
+
+
+class TestEstimateMaxTotalCost:
+    def test_upper_bound_exceeds_input_only_estimate(
+        self, simple_schema, report_text_df
+    ):
+        config = _make_config(simple_schema)
+        input_cost = estimate_input_token_cost(
+            config, report_text_df, console_log_level="ERROR"
+        )
+        max_cost = estimate_max_total_cost(
+            config, report_text_df, console_log_level="ERROR"
+        )
+        assert input_cost > 0
+        assert max_cost > input_cost
+
+    def test_upper_bound_scales_with_max_completion_tokens(
+        self, simple_schema, report_text_df
+    ):
+        small_cfg = _make_config(simple_schema, max_completion_tokens=100)
+        large_cfg = _make_config(simple_schema, max_completion_tokens=10_000)
+        small_bound = estimate_max_total_cost(
+            small_cfg, report_text_df, console_log_level="ERROR"
+        )
+        large_bound = estimate_max_total_cost(
+            large_cfg, report_text_df, console_log_level="ERROR"
+        )
+        assert large_bound > small_bound
+
+    def test_upper_bound_formula_with_known_prices(self, simple_schema, report_text_df):
+        """Output part of the bound must equal output_price * n_chunks * cap."""
+        input_price = 1.0
+        output_price = 2.0
+        max_completion_tokens = 100
+        config = _make_config(
+            simple_schema,
+            model_input_cost_per_1M_tokens=input_price,
+            model_output_cost_per_1M_tokens=output_price,
+            max_completion_tokens=max_completion_tokens,
+        )
+        input_cost = estimate_input_token_cost(
+            config, report_text_df, console_log_level="ERROR"
+        )
+        max_cost = estimate_max_total_cost(
+            config, report_text_df, console_log_level="ERROR"
+        )
+        n_chunks = len(report_text_df)
+        # Prompts here are tiny, so the context window never binds and each
+        # chunk contributes exactly max_completion_tokens of output.
+        expected_output_cost = (
+            n_chunks * max_completion_tokens * output_price / 1_000_000
+        )
+        assert max_cost == pytest.approx(input_cost + expected_output_cost)
+
+    def test_unknown_model_with_manual_prices_falls_back(
+        self, simple_schema, report_text_df
+    ):
+        config = _make_config(
+            simple_schema,
+            model="totally-unknown-model-xyz-123",
+            model_input_cost_per_1M_tokens=1.0,
+            model_output_cost_per_1M_tokens=2.0,
+            max_completion_tokens=1000,
+        )
+        max_cost = estimate_max_total_cost(
+            config, report_text_df, console_log_level="ERROR"
+        )
+        assert max_cost > 0

--- a/tests/unit/cost_estimation/test_cost_estimation.py
+++ b/tests/unit/cost_estimation/test_cost_estimation.py
@@ -3,14 +3,18 @@ Unit tests for offline cost estimation, including the upper-bound estimate
 from issue #44. No API calls are made.
 """
 
+from unittest.mock import patch
+
 import pandas as pd
 import pytest
 
-from delm import DELMConfig, Schema
+from delm import DELM, DELMConfig, Schema
 from delm.models import ExtractionVariable
+from delm.utils.cost_tracker import CostTracker
 from delm.utils.cost_estimation import (
     estimate_input_token_cost,
     estimate_max_total_cost,
+    estimate_total_cost,
 )
 
 
@@ -123,3 +127,47 @@ class TestEstimateMaxTotalCost:
             config, report_text_df, console_log_level="ERROR"
         )
         assert max_cost > 0
+
+
+class TestEstimateTotalCostScaling:
+    """estimate_total_cost must scale by token share, not record count (issue #66)."""
+
+    def _run_with_mocked_llm(self, config, records_df, sample_size, sample_cost):
+        with (
+            patch.object(DELM, "process_via_llm", return_value=pd.DataFrame()),
+            patch.object(CostTracker, "get_current_cost", return_value=sample_cost),
+        ):
+            return estimate_total_cost(
+                config,
+                records_df,
+                sample_size=sample_size,
+                console_log_level="ERROR",
+            )
+
+    def test_uniform_records_scale_like_record_count(self, simple_schema):
+        """With identical records, token share equals record share."""
+        n_records = 4
+        records_df = pd.DataFrame({"text": ["Same text for every record."] * n_records})
+        config = _make_config(simple_schema)
+        estimate = self._run_with_mocked_llm(
+            config, records_df, sample_size=1, sample_cost=1.0
+        )
+        assert estimate == pytest.approx(n_records)
+
+    def test_skewed_records_scale_by_token_share(self, simple_schema):
+        """Sampling a short record must not scale as if all records were short."""
+        records_df = pd.DataFrame(
+            {"text": ["short text", "long text " * 300, "long text " * 300]}
+        )
+        config = _make_config(simple_schema)
+        estimates = {
+            sample_size: self._run_with_mocked_llm(
+                config, records_df, sample_size=sample_size, sample_cost=1.0
+            )
+            for sample_size in [1, 3]
+        }
+        # Record-count scaling would give exactly 3.0 for sample_size=1; token
+        # scaling gives the true token ratio, which differs for skewed data.
+        assert estimates[1] != pytest.approx(3.0)
+        # Full sample must scale by exactly 1 regardless of skew.
+        assert estimates[3] == pytest.approx(1.0)

--- a/tests/unit/cost_tracker/test_cost_tracker.py
+++ b/tests/unit/cost_tracker/test_cost_tracker.py
@@ -14,6 +14,7 @@ from delm.utils.cost_tracker import CostTracker, get_tokenizer_for_model
 
 class MockResponse(BaseModel):
     """Mock Pydantic response for testing."""
+
     field1: str
     field2: int
     field3: list[str]
@@ -21,14 +22,14 @@ class MockResponse(BaseModel):
 
 class TestCostTrackerInitialization:
     """Test CostTracker initialization."""
-    
-    @patch('delm.utils.cost_tracker.get_model_token_price')
+
+    @patch("delm.utils.cost_tracker.get_model_token_price")
     def test_initialization_with_default_prices(self, mock_get_price):
         """Test initialization with default prices from database."""
         mock_get_price.return_value = (0.15, 0.60)
-        
+
         tracker = CostTracker("openai", "gpt-4")
-        
+
         assert tracker.provider == "openai"
         assert tracker.model == "gpt-4"
         assert tracker.model_input_cost_per_1M_tokens == 0.15
@@ -38,7 +39,7 @@ class TestCostTrackerInitialization:
         assert tracker.max_budget is None
         assert tracker.count_cache_hits_towards_cost is False
         assert tracker.tokenizer is not None
-    
+
     def test_tokenizer_matches_model_encoding(self):
         """gpt-4o models use o200k_base; older models use cl100k_base (issue #62)."""
         assert (
@@ -48,287 +49,354 @@ class TestCostTrackerInitialization:
         assert get_tokenizer_for_model("gpt-4").name == "cl100k_base"
         assert get_tokenizer_for_model("unknown-model-xyz").name == "cl100k_base"
 
-    @patch('delm.utils.cost_tracker.get_model_token_price')
+    @patch("delm.utils.cost_tracker.get_model_token_price")
     def test_tracker_uses_model_specific_encoding(self, mock_get_price):
         mock_get_price.return_value = (0.15, 0.60)
         tracker = CostTracker("openai", "gpt-4o-mini")
         assert tracker.tokenizer.name == tiktoken.encoding_for_model("gpt-4o-mini").name
 
+    def test_reservation_without_budget_is_noop(self):
+        tracker = CostTracker(
+            "openai",
+            "gpt-4",
+            model_input_cost_per_1M_tokens=1.0,
+            model_output_cost_per_1M_tokens=2.0,
+        )
+        reserved = tracker.try_reserve_budget(1_000_000, 1_000_000)
+        assert reserved == 0.0
+        assert tracker.reserved_cost == 0.0
+        tracker.release_budget_reservation(reserved)
+
+    def test_reservation_within_budget_succeeds(self):
+        tracker = CostTracker(
+            "openai",
+            "gpt-4",
+            max_budget=10.0,
+            model_input_cost_per_1M_tokens=1.0,
+            model_output_cost_per_1M_tokens=2.0,
+        )
+        # 1M input ($1) + 1M output ($2) = $3 reserved
+        reserved = tracker.try_reserve_budget(1_000_000, 1_000_000)
+        assert reserved == pytest.approx(3.0)
+        assert tracker.reserved_cost == pytest.approx(3.0)
+        tracker.release_budget_reservation(reserved)
+        assert tracker.reserved_cost == 0.0
+
+    def test_reservation_denied_when_budget_exceeded(self):
+        tracker = CostTracker(
+            "openai",
+            "gpt-4",
+            max_budget=5.0,
+            model_input_cost_per_1M_tokens=1.0,
+            model_output_cost_per_1M_tokens=2.0,
+        )
+        first = tracker.try_reserve_budget(1_000_000, 1_000_000)  # $3
+        assert first is not None
+        second = tracker.try_reserve_budget(1_000_000, 1_000_000)  # would be $6 total
+        assert second is None
+        assert tracker.reserved_cost == pytest.approx(3.0)
+
+    def test_reservation_accounts_for_already_tracked_cost(self):
+        tracker = CostTracker(
+            "openai",
+            "gpt-4",
+            max_budget=5.0,
+            model_input_cost_per_1M_tokens=1.0,
+            model_output_cost_per_1M_tokens=2.0,
+        )
+        tracker.track_token_usage(3_000_000, 0)  # $3 actual spend
+        denied = tracker.try_reserve_budget(1_000_000, 1_000_000)  # $3 more
+        assert denied is None
+        allowed = tracker.try_reserve_budget(1_000_000, 0)  # $1 more
+        assert allowed == pytest.approx(1.0)
+
     def test_initialization_with_custom_prices(self):
         """Test initialization with custom prices."""
         tracker = CostTracker(
-            "openai", 
+            "openai",
             "gpt-4",
             model_input_cost_per_1M_tokens=0.20,
-            model_output_cost_per_1M_tokens=0.80
+            model_output_cost_per_1M_tokens=0.80,
         )
-        
+
         assert tracker.model_input_cost_per_1M_tokens == 0.20
         assert tracker.model_output_cost_per_1M_tokens == 0.80
-    
-    @patch('delm.utils.cost_tracker.get_model_token_price')
+
+    @patch("delm.utils.cost_tracker.get_model_token_price")
     def test_initialization_with_budget(self, mock_get_price):
         """Test initialization with budget limit."""
         mock_get_price.return_value = (0.15, 0.60)
         tracker = CostTracker("openai", "gpt-4o-mini", max_budget=10.0)
-        
+
         assert tracker.max_budget == 10.0
-    
-    @patch('delm.utils.cost_tracker.get_model_token_price')
+
+    @patch("delm.utils.cost_tracker.get_model_token_price")
     def test_initialization_with_cache_hits_counting(self, mock_get_price):
         """Test initialization with cache hits counting enabled."""
         mock_get_price.return_value = (0.15, 0.60)
-        tracker = CostTracker("openai", "gpt-4o-mini", count_cache_hits_towards_cost=True)
-        
+        tracker = CostTracker(
+            "openai", "gpt-4o-mini", count_cache_hits_towards_cost=True
+        )
+
         assert tracker.count_cache_hits_towards_cost is True
 
 
 class TestCostTrackerTokenCounting:
     """Test token counting functionality."""
-    
+
     def setup_method(self):
         """Set up test tracker."""
         self.tracker = CostTracker(
-            "openai", 
+            "openai",
             "gpt-4",
             model_input_cost_per_1M_tokens=0.15,
-            model_output_cost_per_1M_tokens=0.60
+            model_output_cost_per_1M_tokens=0.60,
         )
-    
+
     def test_count_tokens_simple_text(self):
         """Test counting tokens in simple text."""
         text = "Hello world"
         tokens = self.tracker.count_tokens(text)
-        
+
         assert isinstance(tokens, int)
         assert tokens > 0
-    
+
     def test_count_tokens_empty_text(self):
         """Test counting tokens in empty text."""
         text = ""
         tokens = self.tracker.count_tokens(text)
-        
+
         assert tokens == 0
-    
+
     def test_count_tokens_long_text(self):
         """Test counting tokens in long text."""
         text = "This is a much longer text that should have more tokens. " * 10
         tokens = self.tracker.count_tokens(text)
-        
+
         assert tokens > 0
         assert tokens > self.tracker.count_tokens("Hello world")
-    
+
     def test_count_tokens_batch(self):
         """Test counting tokens in a batch of texts."""
         texts = ["Hello", "World", "Test"]
         total_tokens = self.tracker.count_tokens_batch(texts)
-        
+
         expected_tokens = sum(self.tracker.count_tokens(text) for text in texts)
         assert total_tokens == expected_tokens
-    
+
     def test_count_tokens_batch_empty(self):
         """Test counting tokens in empty batch."""
         texts = []
         total_tokens = self.tracker.count_tokens_batch(texts)
-        
+
         assert total_tokens == 0
 
 
 class TestCostTrackerTokenTracking:
     """Test token tracking functionality."""
-    
+
     def setup_method(self):
         """Set up test tracker."""
         self.tracker = CostTracker(
-            "openai", 
+            "openai",
             "gpt-4",
             model_input_cost_per_1M_tokens=0.15,
-            model_output_cost_per_1M_tokens=0.60
+            model_output_cost_per_1M_tokens=0.60,
         )
-    
+
     def test_track_input_text(self):
         """Test tracking input text tokens."""
         initial_tokens = self.tracker.input_tokens
         text = "Hello world"
-        
+
         self.tracker.track_input_text(text)
-        
+
         assert self.tracker.input_tokens > initial_tokens
-        assert self.tracker.input_tokens == initial_tokens + self.tracker.count_tokens(text)
-    
+        assert self.tracker.input_tokens == initial_tokens + self.tracker.count_tokens(
+            text
+        )
+
     def test_track_output_text(self):
         """Test tracking output text tokens."""
         initial_tokens = self.tracker.output_tokens
         text = "Response text"
-        
+
         self.tracker.track_output_text(text)
-        
+
         assert self.tracker.output_tokens > initial_tokens
-        assert self.tracker.output_tokens == initial_tokens + self.tracker.count_tokens(text)
-    
+        assert self.tracker.output_tokens == initial_tokens + self.tracker.count_tokens(
+            text
+        )
+
     def test_track_output_pydantic(self):
         """Test tracking Pydantic output tokens."""
         initial_tokens = self.tracker.output_tokens
         response = MockResponse(field1="test", field2=123, field3=["a", "b"])
-        
+
         self.tracker.track_output_pydantic(response)
-        
+
         assert self.tracker.output_tokens > initial_tokens
         # Should count tokens in the JSON representation
         expected_json = json.dumps(response.model_dump(mode="json"))
         expected_tokens = self.tracker.count_tokens(expected_json)
         assert self.tracker.output_tokens == initial_tokens + expected_tokens
-    
+
     def test_track_multiple_inputs(self):
         """Test tracking multiple input texts."""
         texts = ["Hello", "World", "Test"]
         initial_tokens = self.tracker.input_tokens
-        
+
         for text in texts:
             self.tracker.track_input_text(text)
-        
-        expected_total = initial_tokens + sum(self.tracker.count_tokens(text) for text in texts)
+
+        expected_total = initial_tokens + sum(
+            self.tracker.count_tokens(text) for text in texts
+        )
         assert self.tracker.input_tokens == expected_total
-    
+
     def test_track_multiple_outputs(self):
         """Test tracking multiple output texts."""
         texts = ["Response 1", "Response 2", "Response 3"]
         initial_tokens = self.tracker.output_tokens
-        
+
         for text in texts:
             self.tracker.track_output_text(text)
-        
-        expected_total = initial_tokens + sum(self.tracker.count_tokens(text) for text in texts)
+
+        expected_total = initial_tokens + sum(
+            self.tracker.count_tokens(text) for text in texts
+        )
         assert self.tracker.output_tokens == expected_total
 
 
 class TestCostTrackerCostCalculation:
     """Test cost calculation functionality."""
-    
+
     def setup_method(self):
         """Set up test tracker."""
         self.tracker = CostTracker(
-            "openai", 
+            "openai",
             "gpt-4",
             model_input_cost_per_1M_tokens=0.15,
-            model_output_cost_per_1M_tokens=0.60
+            model_output_cost_per_1M_tokens=0.60,
         )
-    
+
     def test_estimate_cost_zero_tokens(self):
         """Test cost estimation with zero tokens."""
         cost = self.tracker.estimate_cost(0, 0)
-        
+
         assert cost == 0.0
-    
+
     def test_estimate_cost_input_only(self):
         """Test cost estimation with input tokens only."""
         cost = self.tracker.estimate_cost(1000, 0)
-        
+
         expected_cost = 1000 * 0.15 / 1_000_000
         assert cost == expected_cost
-    
+
     def test_estimate_cost_output_only(self):
         """Test cost estimation with output tokens only."""
         cost = self.tracker.estimate_cost(0, 1000)
-        
+
         expected_cost = 1000 * 0.60 / 1_000_000
         assert cost == expected_cost
-    
+
     def test_estimate_cost_both_input_output(self):
         """Test cost estimation with both input and output tokens."""
         cost = self.tracker.estimate_cost(1000, 500)
-        
+
         expected_input_cost = 1000 * 0.15 / 1_000_000
         expected_output_cost = 500 * 0.60 / 1_000_000
         expected_total = expected_input_cost + expected_output_cost
         assert cost == expected_total
-    
+
     def test_get_current_cost_no_tokens(self):
         """Test current cost with no tokens tracked."""
         cost = self.tracker.get_current_cost()
-        
+
         assert cost == 0.0
-    
+
     def test_get_current_cost_with_tokens(self):
         """Test current cost with tokens tracked."""
         self.tracker.track_input_text("Hello world")
         self.tracker.track_output_text("Response")
-        
+
         cost = self.tracker.get_current_cost()
-        
+
         assert cost > 0.0
         assert cost == self.tracker.estimate_cost(
-            self.tracker.input_tokens, 
-            self.tracker.output_tokens
+            self.tracker.input_tokens, self.tracker.output_tokens
         )
 
 
 class TestCostTrackerBudgetChecking:
     """Test budget checking functionality."""
-    
-    @patch('delm.utils.cost_tracker.get_model_token_price')
+
+    @patch("delm.utils.cost_tracker.get_model_token_price")
     def test_is_over_budget_no_budget(self, mock_get_price):
         """Test budget check when no budget is set."""
         mock_get_price.return_value = (0.15, 0.60)
         tracker = CostTracker("openai", "gpt-4o-mini")
-        
+
         assert tracker.is_over_budget() is False
-    
+
     def test_is_over_budget_under_budget(self):
         """Test budget check when under budget."""
         tracker = CostTracker(
-            "openai", 
+            "openai",
             "gpt-4",
             max_budget=10.0,
             model_input_cost_per_1M_tokens=0.15,
-            model_output_cost_per_1M_tokens=0.60
+            model_output_cost_per_1M_tokens=0.60,
         )
-        
+
         # Add some tokens but stay under budget
         tracker.track_input_text("Hello")
         tracker.track_output_text("Response")
-        
+
         assert tracker.is_over_budget() is False
-    
+
     def test_is_over_budget_over_budget(self):
         """Test budget check when over budget."""
         tracker = CostTracker(
-            "openai", 
+            "openai",
             "gpt-4",
             max_budget=0.0001,  # Very small budget
             model_input_cost_per_1M_tokens=0.15,
-            model_output_cost_per_1M_tokens=0.60
+            model_output_cost_per_1M_tokens=0.60,
         )
-        
+
         # Add enough tokens to exceed budget
-        long_text = "This is a very long text that should generate enough tokens to exceed the budget. " * 100
+        long_text = (
+            "This is a very long text that should generate enough tokens to exceed the budget. "
+            * 100
+        )
         tracker.track_input_text(long_text)
         tracker.track_output_text(long_text)
-        
+
         assert tracker.is_over_budget() is True
 
 
 class TestCostTrackerSummary:
     """Test cost summary functionality."""
-    
+
     def setup_method(self):
         """Set up test tracker."""
         self.tracker = CostTracker(
-            "openai", 
+            "openai",
             "gpt-4",
             max_budget=10.0,
             model_input_cost_per_1M_tokens=0.15,
-            model_output_cost_per_1M_tokens=0.60
+            model_output_cost_per_1M_tokens=0.60,
         )
-        
+
         # Add some tokens
         self.tracker.track_input_text("Hello world")
         self.tracker.track_output_text("Response")
-    
+
     def test_get_cost_summary_dict(self):
         """Test getting cost summary as dictionary."""
         summary = self.tracker.get_cost_summary_dict()
-        
+
         assert summary["provider"] == "openai"
         assert summary["model"] == "gpt-4"
         assert summary["input_tokens"] == self.tracker.input_tokens
@@ -337,14 +405,14 @@ class TestCostTrackerSummary:
         assert summary["model_output_cost_per_1M_tokens"] == 0.60
         assert "total_cost" in summary
         assert summary["total_cost"] == self.tracker.get_current_cost()
-    
+
     def test_print_cost_summary(self, capsys):
         """Test printing cost summary."""
         self.tracker.print_cost_summary()
-        
+
         captured = capsys.readouterr()
         output = captured.out
-        
+
         assert "Cost Summary (ESTIMATED)" in output
         assert "openai/gpt-4" in output
         assert "Input tokens:" in output
@@ -354,25 +422,25 @@ class TestCostTrackerSummary:
 
 class TestCostTrackerSerialization:
     """Test serialization and deserialization functionality."""
-    
+
     def setup_method(self):
         """Set up test tracker."""
         self.tracker = CostTracker(
-            "openai", 
+            "openai",
             "gpt-4",
             max_budget=10.0,
             model_input_cost_per_1M_tokens=0.15,
-            model_output_cost_per_1M_tokens=0.60
+            model_output_cost_per_1M_tokens=0.60,
         )
-        
+
         # Add some tokens
         self.tracker.track_input_text("Hello world")
         self.tracker.track_output_text("Response")
-    
+
     def test_to_dict(self):
         """Test converting tracker to dictionary."""
         state_dict = self.tracker.to_dict()
-        
+
         assert state_dict["provider"] == "openai"
         assert state_dict["model"] == "gpt-4"
         assert state_dict["max_budget"] == 10.0
@@ -380,8 +448,8 @@ class TestCostTrackerSerialization:
         assert state_dict["output_tokens"] == self.tracker.output_tokens
         assert state_dict["model_input_cost_per_1M_tokens"] == 0.15
         assert state_dict["model_output_cost_per_1M_tokens"] == 0.60
-    
-    @patch('delm.utils.cost_tracker.get_model_token_price')
+
+    @patch("delm.utils.cost_tracker.get_model_token_price")
     def test_from_dict(self, mock_get_price):
         """Test creating tracker from dictionary."""
         mock_get_price.return_value = (0.20, 0.80)
@@ -392,11 +460,11 @@ class TestCostTrackerSerialization:
             "input_tokens": 100,
             "output_tokens": 50,
             "model_input_cost_per_1M_tokens": 0.20,
-            "model_output_cost_per_1M_tokens": 0.80
+            "model_output_cost_per_1M_tokens": 0.80,
         }
-        
+
         tracker = CostTracker.from_dict(state_dict)
-        
+
         assert tracker.provider == "anthropic"
         assert tracker.model == "claude-3-5-sonnet-20241022"
         assert tracker.max_budget == 5.0
@@ -404,18 +472,15 @@ class TestCostTrackerSerialization:
         assert tracker.output_tokens == 50
         assert tracker.model_input_cost_per_1M_tokens == 0.20
         assert tracker.model_output_cost_per_1M_tokens == 0.80
-    
-    @patch('delm.utils.cost_tracker.get_model_token_price')
+
+    @patch("delm.utils.cost_tracker.get_model_token_price")
     def test_from_dict_missing_optional_fields(self, mock_get_price):
         """Test creating tracker from dictionary with missing optional fields."""
         mock_get_price.return_value = (0.15, 0.60)
-        state_dict = {
-            "provider": "openai",
-            "model": "gpt-4o-mini"
-        }
-        
+        state_dict = {"provider": "openai", "model": "gpt-4o-mini"}
+
         tracker = CostTracker.from_dict(state_dict)
-        
+
         assert tracker.provider == "openai"
         assert tracker.model == "gpt-4o-mini"
         assert tracker.max_budget is None
@@ -423,50 +488,58 @@ class TestCostTrackerSerialization:
         assert tracker.output_tokens == 0
         assert tracker.model_input_cost_per_1M_tokens == 0.0
         assert tracker.model_output_cost_per_1M_tokens == 0.0
-    
-    @patch('delm.utils.cost_tracker.get_model_token_price')
+
+    @patch("delm.utils.cost_tracker.get_model_token_price")
     def test_round_trip_serialization(self, mock_get_price):
         """Test round-trip serialization and deserialization."""
         mock_get_price.return_value = (0.15, 0.60)
         original_tracker = self.tracker
-        
+
         # Convert to dict and back
         state_dict = original_tracker.to_dict()
         restored_tracker = CostTracker.from_dict(state_dict)
-        
+
         # Check that all important fields are preserved
         assert restored_tracker.provider == original_tracker.provider
         assert restored_tracker.model == original_tracker.model
         assert restored_tracker.max_budget == original_tracker.max_budget
         assert restored_tracker.input_tokens == original_tracker.input_tokens
         assert restored_tracker.output_tokens == original_tracker.output_tokens
-        assert restored_tracker.model_input_cost_per_1M_tokens == original_tracker.model_input_cost_per_1M_tokens
-        assert restored_tracker.model_output_cost_per_1M_tokens == original_tracker.model_output_cost_per_1M_tokens
+        assert (
+            restored_tracker.model_input_cost_per_1M_tokens
+            == original_tracker.model_input_cost_per_1M_tokens
+        )
+        assert (
+            restored_tracker.model_output_cost_per_1M_tokens
+            == original_tracker.model_output_cost_per_1M_tokens
+        )
 
 
 class TestCostTrackerEdgeCases:
     """Test edge cases and error conditions."""
-    
+
     def test_very_large_token_counts(self):
         """Test handling of very large token counts."""
         tracker = CostTracker(
-            "openai", 
+            "openai",
             "gpt-4o-mini",
             model_input_cost_per_1M_tokens=0.15,
-            model_output_cost_per_1M_tokens=0.60
+            model_output_cost_per_1M_tokens=0.60,
         )
-        
+
         # Simulate very large token counts
         tracker.input_tokens = 1_000_000
         tracker.output_tokens = 500_000
-        
+
         cost = tracker.get_current_cost()
-        
+
         # Should calculate correctly without overflow
         expected_cost = (1_000_000 * 0.15 + 500_000 * 0.60) / 1_000_000
-        assert abs(cost - expected_cost) < 1e-10  # Use approximate comparison for floating point
-    
-    @patch('delm.utils.cost_tracker.get_model_token_price')
+        assert (
+            abs(cost - expected_cost) < 1e-10
+        )  # Use approximate comparison for floating point
+
+    @patch("delm.utils.cost_tracker.get_model_token_price")
     def test_zero_cost_rates(self, mock_get_price):
         """Test handling of zero cost rates."""
         mock_get_price.return_value = (0.15, 0.60)
@@ -474,49 +547,46 @@ class TestCostTrackerEdgeCases:
             "openai",
             "gpt-4o-mini",
             model_input_cost_per_1M_tokens=0.0,
-            model_output_cost_per_1M_tokens=0.0
+            model_output_cost_per_1M_tokens=0.0,
         )
-        
+
         tracker.track_input_text("Hello world")
         tracker.track_output_text("Response")
-        
+
         cost = tracker.get_current_cost()
         assert cost == 0.0
-    
+
     def test_negative_budget(self):
         """Test handling of negative budget."""
-        tracker = CostTracker(
-            "openai",
-            "gpt-4o-mini",
-            max_budget=-1.0
-        )
-        
+        tracker = CostTracker("openai", "gpt-4o-mini", max_budget=-1.0)
+
         # Should not raise an error, but should always be over budget
         assert tracker.is_over_budget() is True
-    
+
     def test_pydantic_response_with_complex_data(self):
         """Test tracking Pydantic response with complex nested data."""
+
         class ComplexResponse(BaseModel):
             text: str
             metadata: dict
             scores: list[float]
             nested: dict[str, list[str]]
-        
+
         response = ComplexResponse(
             text="Sample response",
             metadata={"key": "value", "count": 42},
             scores=[0.1, 0.2, 0.3, 0.4, 0.5],
-            nested={"category": ["a", "b", "c"], "tags": ["x", "y"]}
+            nested={"category": ["a", "b", "c"], "tags": ["x", "y"]},
         )
-        
+
         tracker = CostTracker(
-            "openai", 
+            "openai",
             "gpt-4o-mini",
             model_input_cost_per_1M_tokens=0.15,
-            model_output_cost_per_1M_tokens=0.60
+            model_output_cost_per_1M_tokens=0.60,
         )
-        
+
         initial_tokens = tracker.output_tokens
         tracker.track_output_pydantic(response)
-        
-        assert tracker.output_tokens > initial_tokens 
+
+        assert tracker.output_tokens > initial_tokens

--- a/tests/unit/cost_tracker/test_cost_tracker.py
+++ b/tests/unit/cost_tracker/test_cost_tracker.py
@@ -5,9 +5,11 @@ Unit tests for cost_tracker module.
 import pytest
 import json
 from unittest.mock import Mock, patch, MagicMock
+
+import tiktoken
 from pydantic import BaseModel
 
-from delm.utils.cost_tracker import CostTracker
+from delm.utils.cost_tracker import CostTracker, get_tokenizer_for_model
 
 
 class MockResponse(BaseModel):
@@ -37,6 +39,21 @@ class TestCostTrackerInitialization:
         assert tracker.count_cache_hits_towards_cost is False
         assert tracker.tokenizer is not None
     
+    def test_tokenizer_matches_model_encoding(self):
+        """gpt-4o models use o200k_base; older models use cl100k_base (issue #62)."""
+        assert (
+            get_tokenizer_for_model("gpt-4o-mini").name
+            == tiktoken.encoding_for_model("gpt-4o-mini").name
+        )
+        assert get_tokenizer_for_model("gpt-4").name == "cl100k_base"
+        assert get_tokenizer_for_model("unknown-model-xyz").name == "cl100k_base"
+
+    @patch('delm.utils.cost_tracker.get_model_token_price')
+    def test_tracker_uses_model_specific_encoding(self, mock_get_price):
+        mock_get_price.return_value = (0.15, 0.60)
+        tracker = CostTracker("openai", "gpt-4o-mini")
+        assert tracker.tokenizer.name == tiktoken.encoding_for_model("gpt-4o-mini").name
+
     def test_initialization_with_custom_prices(self):
         """Test initialization with custom prices."""
         tracker = CostTracker(

--- a/tests/unit/few_shot/test_few_shot.py
+++ b/tests/unit/few_shot/test_few_shot.py
@@ -1,0 +1,203 @@
+"""
+Unit tests for few-shot example support (issue #32).
+"""
+
+import pytest
+import tiktoken
+
+from delm import DELMConfig, Schema
+from delm.models import ExtractionVariable
+from delm.utils.few_shot import (
+    FEW_SHOT_PLACEHOLDER,
+    FewShotExampleSelector,
+    validate_few_shot_params,
+)
+
+
+@pytest.fixture
+def examples():
+    return [
+        {
+            "text": "Goldman Sachs raised its oil price target.",
+            "output": {"company": "Goldman Sachs"},
+        },
+        {
+            "text": "Barclays sees weakness in gas markets.",
+            "output": {"company": "Barclays"},
+        },
+        {
+            "text": "Deutsche Bank upgraded steel producers.",
+            "output": {"company": "Deutsche Bank"},
+        },
+        {
+            "text": "JP Morgan cut its copper forecast.",
+            "output": {"company": "JP Morgan"},
+        },
+    ]
+
+
+@pytest.fixture
+def simple_schema():
+    return Schema.simple(
+        variables_list=[
+            ExtractionVariable(
+                name="company",
+                description="Company name",
+                data_type="string",
+            )
+        ]
+    )
+
+
+class TestFewShotExampleSelector:
+    def test_selects_first_n_when_not_random(self, examples):
+        selector = FewShotExampleSelector(examples, num_examples=2)
+        selected = selector.select_examples()
+        assert selected == examples[:2]
+
+    def test_num_examples_capped_at_pool_size(self, examples):
+        selector = FewShotExampleSelector(examples, num_examples=10)
+        assert len(selector.select_examples()) == len(examples)
+
+    def test_random_sampling_is_reproducible(self, examples):
+        selector_a = FewShotExampleSelector(
+            examples, num_examples=2, random_sample=True, seed=42
+        )
+        selector_b = FewShotExampleSelector(
+            examples, num_examples=2, random_sample=True, seed=42
+        )
+        draws_a = [
+            tuple(e["text"] for e in selector_a.select_examples()) for _ in range(5)
+        ]
+        draws_b = [
+            tuple(e["text"] for e in selector_b.select_examples()) for _ in range(5)
+        ]
+        assert draws_a == draws_b
+
+    def test_random_sampling_draws_from_pool(self, examples):
+        selector = FewShotExampleSelector(examples, num_examples=2, random_sample=True)
+        for _ in range(10):
+            selected = selector.select_examples()
+            assert len(selected) == 2
+            for example in selected:
+                assert example in examples
+
+    def test_truncation_limits_example_tokens(self, examples):
+        long_example = [{"text": "word " * 500, "output": {"company": "X"}}]
+        selector = FewShotExampleSelector(
+            long_example, num_examples=1, truncate_length=10
+        )
+        block = selector.build_examples_block()
+        text_line = [l for l in block.splitlines() if l.startswith("Text: ")][0]
+        tokenizer = tiktoken.get_encoding("cl100k_base")
+        assert len(tokenizer.encode(text_line.removeprefix("Text: "))) <= 10
+
+    def test_no_truncation_by_default(self, examples):
+        selector = FewShotExampleSelector(examples, num_examples=1)
+        block = selector.build_examples_block()
+        assert examples[0]["text"] in block
+
+    def test_examples_block_contains_outputs_as_json(self, examples):
+        selector = FewShotExampleSelector(examples, num_examples=2)
+        block = selector.build_examples_block()
+        assert '"company": "Goldman Sachs"' in block
+        assert "Example 1:" in block
+        assert "Example 2:" in block
+
+    def test_inject_replaces_placeholder(self, examples):
+        selector = FewShotExampleSelector(examples, num_examples=1)
+        template = f"Before\n{FEW_SHOT_PLACEHOLDER}\nAfter {{text}} {{variables}}"
+        injected = selector.inject_into_template(template)
+        assert FEW_SHOT_PLACEHOLDER not in injected
+        assert "Examples:" in injected
+
+    def test_inject_prepends_without_placeholder(self, examples):
+        selector = FewShotExampleSelector(examples, num_examples=1)
+        template = "Extract {variables} from {text}"
+        injected = selector.inject_into_template(template)
+        assert injected.startswith("Examples:")
+        assert injected.endswith(template)
+
+    def test_injected_template_survives_str_format(self, examples):
+        selector = FewShotExampleSelector(examples, num_examples=2)
+        template = "Extract {variables} from:\n{text}"
+        injected = selector.inject_into_template(template)
+        formatted = injected.format(variables="- company", text="chunk text")
+        assert "chunk text" in formatted
+        assert '"company": "Goldman Sachs"' in formatted
+
+    def test_from_optional_returns_none_without_examples(self):
+        selector = FewShotExampleSelector.from_optional(
+            examples=None,
+            num_examples=3,
+            truncate_length=None,
+            random_sample=False,
+        )
+        assert selector is None
+
+
+class TestFewShotValidation:
+    def test_rejects_empty_examples(self):
+        with pytest.raises(ValueError, match="non-empty list"):
+            validate_few_shot_params([], 1, None)
+
+    def test_rejects_example_missing_output(self):
+        with pytest.raises(ValueError, match="missing keys"):
+            validate_few_shot_params([{"text": "abc"}], 1, None)
+
+    def test_rejects_example_missing_text(self):
+        with pytest.raises(ValueError, match="missing keys"):
+            validate_few_shot_params([{"output": {}}], 1, None)
+
+    def test_rejects_non_dict_example(self):
+        with pytest.raises(ValueError, match="must be a dict"):
+            validate_few_shot_params(["not a dict"], 1, None)
+
+    def test_rejects_non_positive_num_examples(self):
+        examples = [{"text": "a", "output": {}}]
+        with pytest.raises(ValueError, match="positive integer"):
+            validate_few_shot_params(examples, 0, None)
+
+    def test_rejects_non_positive_truncate_length(self):
+        examples = [{"text": "a", "output": {}}]
+        with pytest.raises(ValueError, match="positive integer or None"):
+            validate_few_shot_params(examples, 1, -5)
+
+
+class TestFewShotConfig:
+    def test_default_config_has_no_few_shot(self, simple_schema):
+        config = DELMConfig(schema=simple_schema)
+        assert config.llm_extraction_cfg.few_shot_examples is None
+
+    def test_config_validation_accepts_valid_few_shot(self, simple_schema, examples):
+        config = DELMConfig(
+            schema=simple_schema,
+            few_shot_examples=examples,
+            few_shot_num_examples=2,
+            few_shot_truncate_length=100,
+            few_shot_random_sample=True,
+        )
+        config.validate()
+
+    def test_config_validation_rejects_bad_examples(self, simple_schema):
+        config = DELMConfig(
+            schema=simple_schema,
+            few_shot_examples=[{"text": "missing output"}],
+        )
+        with pytest.raises(ValueError, match="missing keys"):
+            config.validate()
+
+    def test_config_serialization_round_trip(self, simple_schema, examples):
+        config = DELMConfig(
+            schema=simple_schema,
+            few_shot_examples=examples,
+            few_shot_num_examples=2,
+            few_shot_truncate_length=64,
+            few_shot_random_sample=True,
+        )
+        restored = DELMConfig.from_dict(config.to_dict())
+        llm_cfg = restored.llm_extraction_cfg
+        assert llm_cfg.few_shot_examples == examples
+        assert llm_cfg.few_shot_num_examples == 2
+        assert llm_cfg.few_shot_truncate_length == 64
+        assert llm_cfg.few_shot_random_sample is True

--- a/tests/unit/few_shot/test_few_shot.py
+++ b/tests/unit/few_shot/test_few_shot.py
@@ -8,7 +8,6 @@ import tiktoken
 from delm import DELMConfig, Schema
 from delm.models import ExtractionVariable
 from delm.utils.few_shot import (
-    FEW_SHOT_PLACEHOLDER,
     FewShotExampleSelector,
     validate_few_shot_params,
 )
@@ -104,27 +103,14 @@ class TestFewShotExampleSelector:
         assert "Example 1:" in block
         assert "Example 2:" in block
 
-    def test_inject_replaces_placeholder(self, examples):
-        selector = FewShotExampleSelector(examples, num_examples=1)
-        template = f"Before\n{FEW_SHOT_PLACEHOLDER}\nAfter {{text}} {{variables}}"
-        injected = selector.inject_into_template(template)
-        assert FEW_SHOT_PLACEHOLDER not in injected
-        assert "Examples:" in injected
-
-    def test_inject_prepends_without_placeholder(self, examples):
-        selector = FewShotExampleSelector(examples, num_examples=1)
-        template = "Extract {variables} from {text}"
-        injected = selector.inject_into_template(template)
-        assert injected.startswith("Examples:")
-        assert injected.endswith(template)
-
-    def test_injected_template_survives_str_format(self, examples):
+    def test_prepend_adds_examples_block_once(self, examples):
         selector = FewShotExampleSelector(examples, num_examples=2)
-        template = "Extract {variables} from:\n{text}"
-        injected = selector.inject_into_template(template)
-        formatted = injected.format(variables="- company", text="chunk text")
-        assert "chunk text" in formatted
-        assert '"company": "Goldman Sachs"' in formatted
+        prompt = "Extract - company from:\nchunk text"
+        result = selector.prepend_to_prompt(prompt)
+        assert result.startswith("Examples:")
+        assert result.endswith(prompt)
+        assert result.count("Examples:") == 1
+        assert '"company": "Goldman Sachs"' in result
 
     def test_from_optional_returns_none_without_examples(self):
         selector = FewShotExampleSelector.from_optional(
@@ -134,6 +120,41 @@ class TestFewShotExampleSelector:
             random_sample=False,
         )
         assert selector is None
+
+
+class TestFewShotWithMultipleSchema:
+    def test_examples_block_appears_once_for_multiple_schema(self, examples):
+        """MultipleSchema repeats the template per sub-schema; the examples
+        block must still appear exactly once in the final prompt."""
+        multiple_schema = Schema.multiple(
+            companies=Schema.simple(
+                variables_list=[
+                    ExtractionVariable(
+                        name="company",
+                        description="Company name",
+                        data_type="string",
+                    )
+                ]
+            ),
+            prices=Schema.simple(
+                variables_list=[
+                    ExtractionVariable(
+                        name="price",
+                        description="Price value",
+                        data_type="number",
+                    )
+                ]
+            ),
+        )
+        selector = FewShotExampleSelector(examples, num_examples=2)
+        prompt = multiple_schema.schema.create_prompt(
+            "chunk text",
+            "Extract the following information from the text:\n\n{variables}\n\nText to analyze:\n{text}",
+        )
+        prompt = selector.prepend_to_prompt(prompt)
+        assert prompt.count("Examples:") == 1
+        assert prompt.count("## COMPANIES") == 1
+        assert prompt.count("## PRICES") == 1
 
 
 class TestFewShotValidation:

--- a/tests/unit/model_price_database/test_model_price_database.py
+++ b/tests/unit/model_price_database/test_model_price_database.py
@@ -2,8 +2,12 @@
 Unit tests for the tokencost-backed model price database.
 """
 
-import pytest
+from unittest.mock import patch
 
+import pytest
+from tokencost.constants import TOKEN_COSTS
+
+import delm.utils.model_price_database as mpd
 from delm.utils.model_price_database import (
     get_model_token_limits,
     get_model_token_price,
@@ -56,11 +60,34 @@ class TestGetModelTokenPrice:
         assert input_price >= 0
         assert output_price >= 0
 
-    def test_new_model_resolved_via_live_price_refresh(self):
-        """Models missing from the bundled DB are found after a live refresh."""
-        input_price, output_price = get_model_token_price("openai", "gpt-5.6-sol")
-        assert input_price > 0
-        assert output_price > 0
+    def test_missing_model_triggers_one_refresh_and_resolves(self, monkeypatch):
+        """A model missing from the bundled DB resolves after the price feed
+        refresh; the refresh runs at most once per process. The feed is mocked
+        so the test does not depend on network access."""
+        model_key = "test-refresh-only-model"
+        assert model_key not in TOKEN_COSTS
+
+        def fake_refresh(write_file):
+            TOKEN_COSTS[model_key] = {
+                "input_cost_per_token": 1e-6,
+                "output_cost_per_token": 2e-6,
+                "max_input_tokens": 1000,
+                "max_output_tokens": 100,
+            }
+            return TOKEN_COSTS
+
+        monkeypatch.setattr(mpd, "_PRICES_REFRESHED", False)
+        try:
+            with patch.object(
+                mpd, "refresh_prices", side_effect=fake_refresh
+            ) as mock_refresh:
+                input_price, output_price = get_model_token_price("openai", model_key)
+                assert input_price == pytest.approx(1.0)
+                assert output_price == pytest.approx(2.0)
+                assert get_model_token_limits("openai", model_key) == (1000, 100)
+                mock_refresh.assert_called_once()
+        finally:
+            TOKEN_COSTS.pop(model_key, None)
 
 
 class TestGetModelTokenLimits:

--- a/tests/unit/model_price_database/test_model_price_database.py
+++ b/tests/unit/model_price_database/test_model_price_database.py
@@ -4,7 +4,10 @@ Unit tests for the tokencost-backed model price database.
 
 import pytest
 
-from delm.utils.model_price_database import get_model_token_price
+from delm.utils.model_price_database import (
+    get_model_token_limits,
+    get_model_token_price,
+)
 
 
 class TestGetModelTokenPrice:
@@ -52,6 +55,25 @@ class TestGetModelTokenPrice:
         input_price, output_price = get_model_token_price("google", "gemini-2.0-flash")
         assert input_price >= 0
         assert output_price >= 0
+
+    def test_new_model_resolved_via_live_price_refresh(self):
+        """Models missing from the bundled DB are found after a live refresh."""
+        input_price, output_price = get_model_token_price("openai", "gpt-5.6-sol")
+        assert input_price > 0
+        assert output_price > 0
+
+
+class TestGetModelTokenLimits:
+    """Test get_model_token_limits using tokencost backend."""
+
+    def test_known_model_limits(self):
+        max_input, max_output = get_model_token_limits("openai", "gpt-4o-mini")
+        assert max_input is not None and max_input > 0
+        assert max_output is not None and max_output > 0
+
+    def test_unknown_model_raises_value_error(self):
+        with pytest.raises(ValueError, match="not found in tokencost database"):
+            get_model_token_limits("nonexistent_provider", "nonexistent_model_xyz_123")
 
 
 class TestTokencostIntegrationWithCostTracker:

--- a/tests/unit/post_processing/test_post_processing.py
+++ b/tests/unit/post_processing/test_post_processing.py
@@ -11,39 +11,44 @@ from unittest.mock import Mock, patch
 from delm.utils.post_processing import (
     merge_jsons_for_record,
     explode_json_results,
-    _majority_vote
+    _majority_vote,
 )
-from delm.schemas.schemas import SimpleSchema, NestedSchema, MultipleSchema, ExtractionVariable
+from delm.schemas.schemas import (
+    SimpleSchema,
+    NestedSchema,
+    MultipleSchema,
+    ExtractionVariable,
+)
 from delm.constants import SYSTEM_EXTRACTED_DATA_JSON_COLUMN
 from delm.constants import SYSTEM_ERRORS_COLUMN
 
 
 class TestMajorityVote:
     """Test the _majority_vote helper function."""
-    
+
     def test_majority_vote_basic(self):
         """Test basic majority vote functionality."""
         values = ["A", "B", "A", "C", "A"]
         result = _majority_vote(values)
         assert result == "A"
-    
+
     def test_majority_vote_tie(self):
         """Test majority vote with a tie - should return first winner."""
         values = ["A", "B", "A", "B"]
         result = _majority_vote(values)
         assert result == "A"  # First winner wins
-    
+
     def test_majority_vote_empty_list(self):
         """Test majority vote with empty list."""
         result = _majority_vote([])
         assert result is None
-    
+
     def test_majority_vote_single_value(self):
         """Test majority vote with single value."""
         values = ["A"]
         result = _majority_vote(values)
         assert result == "A"
-    
+
     def test_majority_vote_numbers(self):
         """Test majority vote with numbers."""
         values = [1, 2, 1, 3, 1, 2]
@@ -53,39 +58,85 @@ class TestMajorityVote:
 
 class TestMergeJsonsForRecord:
     """Test the merge_jsons_for_record function."""
-    
+
     def setup_method(self):
         """Set up test schemas."""
-        self.simple_schema = SimpleSchema([
-            ExtractionVariable(name="source", data_type="string", required=True, description=""),
-            ExtractionVariable(name="ratings", data_type="[integer]", required=False, description=""),
-            ExtractionVariable(name="price", data_type="number", required=False, description=""),
-        ])
-        
+        self.simple_schema = SimpleSchema(
+            [
+                ExtractionVariable(
+                    name="source", data_type="string", required=True, description=""
+                ),
+                ExtractionVariable(
+                    name="ratings",
+                    data_type="[integer]",
+                    required=False,
+                    description="",
+                ),
+                ExtractionVariable(
+                    name="price", data_type="number", required=False, description=""
+                ),
+            ]
+        )
+
         self.nested_schema = NestedSchema(
             container_name="books",
             variables=[
-                ExtractionVariable(name="title", data_type="string", required=True, description=""),
-                ExtractionVariable(name="author", data_type="string", required=True, description=""),
-                ExtractionVariable(name="sales", data_type="[integer]", required=False, description=""),
-            ]
+                ExtractionVariable(
+                    name="title", data_type="string", required=True, description=""
+                ),
+                ExtractionVariable(
+                    name="author", data_type="string", required=True, description=""
+                ),
+                ExtractionVariable(
+                    name="sales", data_type="[integer]", required=False, description=""
+                ),
+            ],
         )
-        
-        self.multiple_schema = MultipleSchema({
-            "info": SimpleSchema([
-                ExtractionVariable(name="source", data_type="string", required=True, description=""),
-                ExtractionVariable(name="ratings", data_type="[integer]", required=False, description=""),
-            ]),
-            "books": NestedSchema(
-                container_name="entries",
-                variables=[
-                    ExtractionVariable(name="title", data_type="string", required=True, description=""),
-                    ExtractionVariable(name="author", data_type="string", required=True, description=""),
-                    ExtractionVariable(name="sales", data_type="[integer]", required=False, description=""),
-                ]
-            )
-        })
-    
+
+        self.multiple_schema = MultipleSchema(
+            {
+                "info": SimpleSchema(
+                    [
+                        ExtractionVariable(
+                            name="source",
+                            data_type="string",
+                            required=True,
+                            description="",
+                        ),
+                        ExtractionVariable(
+                            name="ratings",
+                            data_type="[integer]",
+                            required=False,
+                            description="",
+                        ),
+                    ]
+                ),
+                "books": NestedSchema(
+                    container_name="entries",
+                    variables=[
+                        ExtractionVariable(
+                            name="title",
+                            data_type="string",
+                            required=True,
+                            description="",
+                        ),
+                        ExtractionVariable(
+                            name="author",
+                            data_type="string",
+                            required=True,
+                            description="",
+                        ),
+                        ExtractionVariable(
+                            name="sales",
+                            data_type="[integer]",
+                            required=False,
+                            description="",
+                        ),
+                    ],
+                ),
+            }
+        )
+
     def test_merge_simple_schema_scalars(self):
         """Test merging simple schema with scalar values."""
         input_jsons = [
@@ -94,11 +145,11 @@ class TestMergeJsonsForRecord:
             {"source": "B", "price": 200},
         ]
         merged = merge_jsons_for_record(input_jsons, self.simple_schema)
-        
+
         assert merged["source"] == "B"  # Majority vote
-        assert merged["price"] == 200   # Majority vote
+        assert merged["price"] == 200  # Majority vote
         assert merged["ratings"] == []  # Empty list for missing field
-    
+
     def test_merge_simple_schema_lists(self):
         """Test merging simple schema with list values."""
         input_jsons = [
@@ -107,10 +158,10 @@ class TestMergeJsonsForRecord:
             {"source": "A", "ratings": [5]},
         ]
         merged = merge_jsons_for_record(input_jsons, self.simple_schema)
-        
+
         assert merged["source"] == "A"  # First winner in tie
         assert merged["ratings"] == [1, 2, 3, 4, 5]  # Concatenated lists
-    
+
     def test_merge_simple_schema_mixed(self):
         """Test merging simple schema with mixed scalar and list values."""
         input_jsons = [
@@ -119,31 +170,31 @@ class TestMergeJsonsForRecord:
             {"source": "B", "price": 200, "ratings": [4]},
         ]
         merged = merge_jsons_for_record(input_jsons, self.simple_schema)
-        
+
         assert merged["source"] == "B"  # Majority vote
-        assert merged["price"] == 200   # Majority vote
+        assert merged["price"] == 200  # Majority vote
         assert merged["ratings"] == [1, 2, 3, 4]  # Concatenated lists
-    
+
     def test_merge_nested_schema(self):
         """Test merging nested schema."""
         input_jsons = [
-            {"books": [
-                {"title": "Book A", "author": "Author X", "sales": [100]},
-                {"title": "Book B", "author": "Author Y", "sales": [200]},
-            ]},
-            {"books": [
-                {"title": "Book C", "author": "Author Z", "sales": [300]}
-            ]},
+            {
+                "books": [
+                    {"title": "Book A", "author": "Author X", "sales": [100]},
+                    {"title": "Book B", "author": "Author Y", "sales": [200]},
+                ]
+            },
+            {"books": [{"title": "Book C", "author": "Author Z", "sales": [300]}]},
         ]
         merged = merge_jsons_for_record(input_jsons, self.nested_schema)
-        
+
         expected_books = [
             {"title": "Book A", "author": "Author X", "sales": [100]},
             {"title": "Book B", "author": "Author Y", "sales": [200]},
             {"title": "Book C", "author": "Author Z", "sales": [300]},
         ]
         assert merged["books"] == expected_books
-    
+
     def test_merge_multiple_schema(self):
         """Test merging multiple schema."""
         input_jsons = [
@@ -152,32 +203,54 @@ class TestMergeJsonsForRecord:
                 "books": [
                     {"title": "Book A", "author": "Author X", "sales": [100]},
                     {"title": "Book B", "author": "Author Y", "sales": [200]},
-                ]
+                ],
             },
             {
                 "info": {"source": "A", "ratings": [2]},
                 "books": [
                     {"title": "Book C", "author": "Author Z", "sales": [300]},
-                ]
-            }
+                ],
+            },
         ]
         merged = merge_jsons_for_record(input_jsons, self.multiple_schema)
-        
+
         assert merged["info"]["source"] == "A"
         assert merged["info"]["ratings"] == [1, 2]
-        
+
         expected_books = [
             {"title": "Book A", "author": "Author X", "sales": [100]},
             {"title": "Book B", "author": "Author Y", "sales": [200]},
             {"title": "Book C", "author": "Author Z", "sales": [300]},
         ]
         assert merged["books"] == expected_books
-    
+
+    def test_merge_multiple_schema_with_malformed_items(self):
+        """MultipleSchema merge must skip None, bad strings, and non-dicts."""
+        input_jsons = [
+            {
+                "info": {"source": "A", "ratings": [1]},
+                "books": [
+                    {"title": "Book A", "author": "Author X", "sales": [100]},
+                ],
+            },
+            "not-json",
+            None,
+            123,
+            '{"info": {"source": "A", "ratings": [2]}, "books": []}',
+        ]
+        merged = merge_jsons_for_record(input_jsons, self.multiple_schema)
+
+        assert merged["info"]["source"] == "A"
+        assert merged["info"]["ratings"] == [1, 2]
+        assert merged["books"] == [
+            {"title": "Book A", "author": "Author X", "sales": [100]},
+        ]
+
     def test_merge_empty_json_list(self):
         """Test merging with empty JSON list."""
         merged = merge_jsons_for_record([], self.simple_schema)
         assert merged == {"source": None, "ratings": [], "price": None}
-    
+
     def test_merge_json_strings(self):
         """Test merging with JSON strings instead of dicts."""
         input_jsons = [
@@ -185,69 +258,130 @@ class TestMergeJsonsForRecord:
             '{"source": "B", "price": 200}',
         ]
         merged = merge_jsons_for_record(input_jsons, self.simple_schema)
-        
+
         assert merged["source"] == "A"  # First value in tie
-        assert merged["price"] == 100   # First value in tie
-    
+        assert merged["price"] == 100  # First value in tie
+
     def test_merge_unknown_schema_type(self):
         """Test merging with unknown schema type."""
         mock_schema = Mock()
         mock_schema.schema_type = "unknown"
-        
+
         with pytest.raises(ValueError, match="Unknown schema type: unknown"):
             merge_jsons_for_record([{"test": "data"}], mock_schema)
 
 
 class TestExplodeJsonResults:
     """Test the explode_json_results function."""
-    
+
     def setup_method(self):
         """Set up test schemas."""
-        self.simple_schema = SimpleSchema([
-            ExtractionVariable(name="company", description="Company name", data_type="string", required=True),
-            ExtractionVariable(name="price", description="Price value", data_type="number", required=False),
-            ExtractionVariable(name="tags", description="Tags", data_type="[string]", required=False),
-        ])
-        
+        self.simple_schema = SimpleSchema(
+            [
+                ExtractionVariable(
+                    name="company",
+                    description="Company name",
+                    data_type="string",
+                    required=True,
+                ),
+                ExtractionVariable(
+                    name="price",
+                    description="Price value",
+                    data_type="number",
+                    required=False,
+                ),
+                ExtractionVariable(
+                    name="tags",
+                    description="Tags",
+                    data_type="[string]",
+                    required=False,
+                ),
+            ]
+        )
+
         self.nested_schema = NestedSchema(
             container_name="books",
             variables=[
-                ExtractionVariable(name="title", description="Book title", data_type="string", required=True),
-                ExtractionVariable(name="author", description="Book author", data_type="string", required=True),
-                ExtractionVariable(name="price", description="Book price", data_type="number", required=False),
-                ExtractionVariable(name="genres", description="Book genres", data_type="[string]", required=False),
-            ]
+                ExtractionVariable(
+                    name="title",
+                    description="Book title",
+                    data_type="string",
+                    required=True,
+                ),
+                ExtractionVariable(
+                    name="author",
+                    description="Book author",
+                    data_type="string",
+                    required=True,
+                ),
+                ExtractionVariable(
+                    name="price",
+                    description="Book price",
+                    data_type="number",
+                    required=False,
+                ),
+                ExtractionVariable(
+                    name="genres",
+                    description="Book genres",
+                    data_type="[string]",
+                    required=False,
+                ),
+            ],
         )
-        
-        self.multiple_schema = MultipleSchema({
-            "books": NestedSchema(
-                container_name="books",
-                variables=[
-                    ExtractionVariable(name="title", description="Book title", data_type="string", required=True),
-                    ExtractionVariable(name="author", description="Book author", data_type="string", required=True),
-                ]
-            ),
-            "authors": NestedSchema(
-                container_name="authors",
-                variables=[
-                    ExtractionVariable(name="name", description="Author name", data_type="string", required=True),
-                    ExtractionVariable(name="genre", description="Author genre", data_type="string", required=False),
-                ]
-            )
-        })
-    
+
+        self.multiple_schema = MultipleSchema(
+            {
+                "books": NestedSchema(
+                    container_name="books",
+                    variables=[
+                        ExtractionVariable(
+                            name="title",
+                            description="Book title",
+                            data_type="string",
+                            required=True,
+                        ),
+                        ExtractionVariable(
+                            name="author",
+                            description="Book author",
+                            data_type="string",
+                            required=True,
+                        ),
+                    ],
+                ),
+                "authors": NestedSchema(
+                    container_name="authors",
+                    variables=[
+                        ExtractionVariable(
+                            name="name",
+                            description="Author name",
+                            data_type="string",
+                            required=True,
+                        ),
+                        ExtractionVariable(
+                            name="genre",
+                            description="Author genre",
+                            data_type="string",
+                            required=False,
+                        ),
+                    ],
+                ),
+            }
+        )
+
     def test_explode_simple_schema(self):
         """Test exploding simple schema results."""
-        input_df = pd.DataFrame({
-            "chunk_id": [1, 2],
-            "json": [
-                '{"company": "Apple", "price": 150.0, "tags": ["tech", "hardware"]}',
-                '{"company": "Microsoft", "price": 300.0, "tags": ["tech", "software", "cloud"]}'
-            ]
-        })
-        
+        input_df = pd.DataFrame(
+            {
+                "chunk_id": [1, 2],
+                "json": [
+                    '{"company": "Apple", "price": 150.0, "tags": ["tech", "hardware"]}',
+                    '{"company": "Microsoft", "price": 300.0, "tags": ["tech", "software", "cloud"]}',
+                ],
+            }
+        )
+
         result = explode_json_results(input_df, self.simple_schema, json_column="json")
-        
+
         assert len(result) == 2
         assert result.iloc[0]["company"] == "Apple"
         assert result.iloc[0]["price"] == 150.0
@@ -256,19 +390,21 @@ class TestExplodeJsonResults:
         assert result.iloc[1]["price"] == 300.0
         assert result.iloc[1]["tags"] == ["tech", "software", "cloud"]
         assert "chunk_id" in result.columns
-    
+
     def test_explode_nested_schema(self):
         """Test exploding nested schema results."""
-        input_df = pd.DataFrame({
-            "chunk_id": [1, 2],
-            "json": [
-                '{"books": [{"title": "Python Guide", "author": "Alice", "price": 29.99, "genres": ["programming", "education"]}, {"title": "Data Science", "author": "Bob", "price": 39.99, "genres": ["programming", "science"]}]}',
-                '{"books": [{"title": "Machine Learning", "author": "Carol", "price": 49.99, "genres": ["AI", "programming"]}]}'
-            ]
-        })
-        
+        input_df = pd.DataFrame(
+            {
+                "chunk_id": [1, 2],
+                "json": [
+                    '{"books": [{"title": "Python Guide", "author": "Alice", "price": 29.99, "genres": ["programming", "education"]}, {"title": "Data Science", "author": "Bob", "price": 39.99, "genres": ["programming", "science"]}]}',
+                    '{"books": [{"title": "Machine Learning", "author": "Carol", "price": 49.99, "genres": ["AI", "programming"]}]}',
+                ],
+            }
+        )
+
         result = explode_json_results(input_df, self.nested_schema, json_column="json")
-        
+
         assert len(result) == 3
         assert result.iloc[0]["title"] == "Python Guide"
         assert result.iloc[0]["author"] == "Alice"
@@ -278,43 +414,51 @@ class TestExplodeJsonResults:
         assert result.iloc[1]["author"] == "Bob"
         assert result.iloc[2]["title"] == "Machine Learning"
         assert result.iloc[2]["author"] == "Carol"
-    
+
     def test_explode_multiple_schema(self):
         """Test exploding multiple schema results."""
-        input_df = pd.DataFrame({
-            "chunk_id": [1, 2],
-            "json": [
-                '{"books": {"books": [{"title": "Python Guide", "author": "Alice"}, {"title": "Data Science", "author": "Bob"}]}, "authors": {"authors": [{"name": "Alice", "genre": "programming"}, {"name": "Bob", "genre": "science"}]}}',
-                '{"books": {"books": [{"title": "Machine Learning", "author": "Carol"}]}, "authors": {"authors": [{"name": "Carol", "genre": "AI"}]}}'
-            ]
-        })
-        
-        result = explode_json_results(input_df, self.multiple_schema, json_column="json")
-        
+        input_df = pd.DataFrame(
+            {
+                "chunk_id": [1, 2],
+                "json": [
+                    '{"books": {"books": [{"title": "Python Guide", "author": "Alice"}, {"title": "Data Science", "author": "Bob"}]}, "authors": {"authors": [{"name": "Alice", "genre": "programming"}, {"name": "Bob", "genre": "science"}]}}',
+                    '{"books": {"books": [{"title": "Machine Learning", "author": "Carol"}]}, "authors": {"authors": [{"name": "Carol", "genre": "AI"}]}}',
+                ],
+            }
+        )
+
+        result = explode_json_results(
+            input_df, self.multiple_schema, json_column="json"
+        )
+
         assert len(result) == 6  # 3 books + 3 authors
         assert "schema_name" in result.columns
-        
+
         # Check books
         books = result[result["schema_name"] == "books"]
         assert len(books) == 3
         assert books.iloc[0]["books_title"] == "Python Guide"
         assert books.iloc[0]["books_author"] == "Alice"
-        
+
         # Check authors
         authors = result[result["schema_name"] == "authors"]
         assert len(authors) == 3
         assert authors.iloc[0]["authors_name"] == "Alice"
         assert authors.iloc[0]["authors_genre"] == "programming"
-    
+
     def test_explode_with_dict_json(self):
         """Test exploding with dict JSON instead of strings."""
-        input_df = pd.DataFrame({
-            "chunk_id": [1],
-            "json": [{"company": "Apple", "price": 150.0, "tags": ["tech", "hardware"]}]
-        })
-        
+        input_df = pd.DataFrame(
+            {
+                "chunk_id": [1],
+                "json": [
+                    {"company": "Apple", "price": 150.0, "tags": ["tech", "hardware"]}
+                ],
+            }
+        )
+
         result = explode_json_results(input_df, self.simple_schema, json_column="json")
-        
+
         assert len(result) == 1
         assert result.iloc[0]["company"] == "Apple"
         assert result.iloc[0]["price"] == 150.0
@@ -341,52 +485,64 @@ class TestExplodeJsonResults:
         assert len(result) == 1
         assert result.iloc[0]["chunk_id"] == 2
         assert result.iloc[0]["company"] == "Apple"
-    
+
     def test_explode_empty_dataframe(self):
         """Test exploding empty DataFrame."""
         input_df = pd.DataFrame(columns=["chunk_id", "json"])
-        
+
         result = explode_json_results(input_df, self.simple_schema, json_column="json")
-        
+
         assert len(result) == 0
-    
+
     def test_explode_missing_json_column(self):
         """Test exploding with missing JSON column."""
         input_df = pd.DataFrame({"chunk_id": [1]})
-        
-        with pytest.raises(ValueError, match="Column json not found in input DataFrame"):
+
+        with pytest.raises(
+            ValueError, match="Column json not found in input DataFrame"
+        ):
             explode_json_results(input_df, self.simple_schema, json_column="json")
-    
+
     def test_explode_with_schema_path(self):
         """Test exploding with schema path instead of schema object.
-        
+
         NOTE: This functionality is no longer supported in the new API.
         The explode_json_results function now requires an ExtractionSchema object,
         not a file path. If you need to load from a file, use Schema.from_yaml()
         first to get the schema object, then pass that to explode_json_results.
         """
-        pytest.skip("Schema path loading is no longer supported - use Schema.from_yaml() first")
+        pytest.skip(
+            "Schema path loading is no longer supported - use Schema.from_yaml() first"
+        )
 
 
 class TestExtractionVariableIsList:
     """Test the is_list method of ExtractionVariable."""
-    
+
     def test_is_list_with_list_type(self):
         """Test is_list method with list data type."""
-        var = ExtractionVariable(name="test", data_type="[string]", required=True, description="")
+        var = ExtractionVariable(
+            name="test", data_type="[string]", required=True, description=""
+        )
         assert var.is_list() is True
-    
+
     def test_is_list_with_scalar_type(self):
         """Test is_list method with scalar data type."""
-        var = ExtractionVariable(name="test", data_type="string", required=True, description="")
+        var = ExtractionVariable(
+            name="test", data_type="string", required=True, description=""
+        )
         assert var.is_list() is False
-    
+
     def test_is_list_with_number_type(self):
         """Test is_list method with number data type."""
-        var = ExtractionVariable(name="test", data_type="number", required=True, description="")
+        var = ExtractionVariable(
+            name="test", data_type="number", required=True, description=""
+        )
         assert var.is_list() is False
-    
+
     def test_is_list_with_integer_list_type(self):
         """Test is_list method with integer list data type."""
-        var = ExtractionVariable(name="test", data_type="[integer]", required=True, description="")
-        assert var.is_list() is True 
+        var = ExtractionVariable(
+            name="test", data_type="[integer]", required=True, description=""
+        )
+        assert var.is_list() is True


### PR DESCRIPTION
## Summary

- Resolves #32 (few-shot examples with truncation and seeded sampling), #44 (`estimate_max_total_cost` upper-bound estimator), and #61-#67 (config forward compatibility, model-specific tiktoken encodings, mypy config, code hygiene, strict `max_budget` enforcement via pre-request reservations, token-share cost extrapolation, docs fixes).
- Pricing now auto-refreshes tokencost's live feed on a database miss, so newly released models (e.g. `claude-fable-5`, `gpt-5.6-sol`) resolve without a package upgrade; `get_model_token_limits()` exposes context windows.
- Supersedes #60: `DELMConfig.from_dict` now only requires `schema` and warns on unknown keys; the regression test from #60 is adopted verbatim.
- Bumps version to 1.2.0 and fixes the release script regex that originally corrupted mypy's `python_version`.

All commits were independently reviewed (three findings fixed: few-shot block duplication for `MultipleSchema`, `merge_jsons_for_record` crash on mixed malformed items, network-dependent unit test).

## Test plan

- [x] `pytest tests/unit -q`: 416 passed, 4 skipped
- [x] New unit tests for few-shot selection/truncation/sampling, upper-bound cost formula, budget reservations, token-share scaling, `from_dict` compatibility, price-feed refresh (mocked)
- [x] Verified pricing lookups for `claude-fable-5` / `gpt-5.6-sol` locally without LLM API spend
